### PR TITLE
Proposal, remove extra question type mapping in fcgi_nextquestion

### DIFF
--- a/backend/src/fcgimain.c
+++ b/backend/src/fcgimain.c
@@ -16,6 +16,7 @@
 #include "errorlog.h"
 #include "survey.h"
 #include "serialisers.h"
+#include "question_types.h"
 
 int kvalid_surveyid(struct kpair *kp) {
   // Only use our validation here, not one of the pre-defined ones
@@ -687,50 +688,41 @@ static void fcgi_nextquestion(struct kreq *r)
       kjson_putstringp(&req,"name",q[i]->uid);
       kjson_putstringp(&req,"title",q[i]->question_html);
       kjson_putstringp(&req,"title_text",q[i]->question_text);
+      kjson_putstringp(&req,"type",question_type_names[q[i]->type]);
+
       switch (q[i]->type)
-	{
-	case QTYPE_FIXEDPOINT:
-	  kjson_putstringp(&req,"type","fixedpoint"); break;
-	case QTYPE_TEXT: kjson_putstringp(&req,"type","text"); break;
-	case QTYPE_MULTICHOICE:
-	case QTYPE_MULTISELECT:
-	  if (q[i]->type==QTYPE_MULTICHOICE)
-	    kjson_putstringp(&req,"type","radiogroup");
-	  else
-	    kjson_putstringp(&req,"type","checkbox");
-	  kjson_arrayp_open(&req,"choices");
-	  int len=strlen(q[i]->choices);
-	  if (len) {
-	    for(int j=0;q[i]->choices[j];) {
-	      char choice[65536];
-	      int cl=0;
-	      choice[0]=0;
-	      while(
-		    ((j+cl)<len)
-		    &&q[i]->choices[j+cl]
-		    &&(q[i]->choices[j+cl]!=',')
-		    )
-		{
-		  if (cl<65535) {
-		    choice[cl]=q[i]->choices[j+cl];
-		    choice[cl+1]=0;
-		  }
-		  cl++;
-		}
-	      kjson_putstring(&req,choice);
-	      j+=cl;
-	      if (q[i]->choices[j+cl]==',') j++;
-	    }
-	  }
-	  kjson_array_close(&req);
-	  break;
-	case QTYPE_DATETIME:
-	  kjson_putstringp(&req,"type","text");
-	  kjson_putstringp(&req,"inputType","date");
-	  break;
-	default:
-	  kjson_putstringp(&req,"type","text"); break;	  
-	}
+    {
+    case QTYPE_MULTICHOICE:
+    case QTYPE_MULTISELECT:
+      kjson_arrayp_open(&req,"choices");
+      int len=strlen(q[i]->choices);
+      if (len) {
+        for(int j=0;q[i]->choices[j];) {
+          char choice[65536];
+          int cl=0;
+          choice[0]=0;
+          while(
+            ((j+cl)<len)
+            &&q[i]->choices[j+cl]
+            &&(q[i]->choices[j+cl]!=',')
+            )
+        {
+          if (cl<65535) {
+            choice[cl]=q[i]->choices[j+cl];
+            choice[cl+1]=0;
+          }
+          cl++;
+        }
+          kjson_putstring(&req,choice);
+          j+=cl;
+          if (q[i]->choices[j+cl]==',') j++;
+        }
+      }
+      kjson_array_close(&req);
+      break;
+    default:
+      break;
+    }
       
       kjson_obj_close(&req);
     }

--- a/backend/tests/001_nextquestionpythonActualLogic.test
+++ b/backend/tests/001_nextquestionpythonActualLogic.test
@@ -44,14 +44,14 @@ endofsession
 # Ask for next question
 request 200 nextquestion?sessionid=$SESSION
 # TODO: this is what I think the answer should look like, but it actually looks like the next uncommented line
-#match_string {"next_questions": [{"id": "password1", "name": "email", "title": "How boring was question 1?", "title_text": "How boring was question 1?", "type": "text"}]}
+#match_string {"next_questions": [{"id": "password1", "name": "email", "title": "How boring was question 1?", "title_text": "How boring was question 1?", "type": "TEXT"}]}
 match_string "email"
 
 request 200 addanswer?sessionid=$SESSION&answer=email:test.email@someDomain.org:0:0:0:0:0:0:0
 
 # Check that we are offered the next question to answer
 # TODO: this is what I think the answer should look like, but it actually looks like the next uncommented line
-#match_string {"next_questions": [{"id": "question2", "name": "question2", "title": "What is the answer to question 1?", "title_text": "What is the answer to question 2?", "type": "text"}]}
+#match_string {"next_questions": [{"id": "question2", "name": "question2", "title": "What is the answer to question 1?", "title_text": "What is the answer to question 2?", "type": "TEXT"}]}
 match_string "password1"
 
 # Make sure answer ends up in file

--- a/backend/tests/002_shouldFAIL_pythonIndentError.test
+++ b/backend/tests/002_shouldFAIL_pythonIndentError.test
@@ -44,5 +44,5 @@ endofsession
 
 # Ask for next question
 request 200 nextquestion?sessionid=$SESSION
-#match_string {"next_questions": [{"id": "password1", "name": "email", "title": "How boring was question 1?", "title_text": "How boring was question 1?", "type": "text"}]}
+#match_string {"next_questions": [{"id": "password1", "name": "email", "title": "How boring was question 1?", "title_text": "How boring was question 1?", "type": "TEXT"}]}
 match_string "email"

--- a/backend/tests/003_outputFromPythonShouldBeSameAsFromC.test
+++ b/backend/tests/003_outputFromPythonShouldBeSameAsFromC.test
@@ -35,14 +35,14 @@ endofsession
 # Ask for next question
 request 200 nextquestion?sessionid=$SESSION
 # TODO: line 38 is what I think the answer should look like, but the output actually looks like line 39
-#match_string {"next_questions": [{"id": "email", "name": "email", "title": "How boring was question 1?", "title_text": "How boring was question 1?", "type": "text"}]}
+#match_string {"next_questions": [{"id": "email", "name": "email", "title": "How boring was question 1?", "title_text": "How boring was question 1?", "type": "TEXT"}]}
 match_string "email"
 
 request 200 addanswer?sessionid=$SESSION&answer=email:test.email@someDomain.org:0:0:0:0:0:0:0
 
 # Check that we are offered the next question to answer
 # TODO: line 45 is what I think the answer should look like, but it actually looks like line 46
-#match_string {"next_questions": [{"id": "password1", "name": "question2", "title": "What is the answer to question 1?", "title_text": "What is the answer to question 2?", "type": "text"}]}
+#match_string {"next_questions": [{"id": "password1", "name": "question2", "title": "What is the answer to question 1?", "title_text": "What is the answer to question 2?", "type": "TEXT"}]}
 match_string "password1"
 
 # Make sure answer ends up in file

--- a/backend/tests/004_pythonAlgSequencedAnswer.test
+++ b/backend/tests/004_pythonAlgSequencedAnswer.test
@@ -45,7 +45,7 @@ endofsession
 request 200 addanswer?sessionid=$SESSION&answer=email:test.email@domain.com:0:0:0:0:0:0:0
 # password1:Password:Password:TEXT:-1:password1:-999:999:2:0:0:
 # Check that we are offered the next question to answer
-match_string {"next_questions": [{"id": "password1", "name": "password1", "title": "Password", "title_text": "Password", "type": "text"}]}
+match_string {"next_questions": [{"id": "password1", "name": "password1", "title": "Password", "title_text": "Password", "type": "TEXT"}]}
 match_string "password1"
 
 # Make sure answer ends up in file
@@ -57,7 +57,7 @@ endofsession
 request 200 addanswer?sessionid=$SESSION&answer=password1:myPaSSw0rD:0:0:0:0:0:0:0
 #
 ## Check that we are offered the next question to answer
-##match_string {"next_questions": [{"id": "password2", "name": "question3", "title": "How boring was question 1?", "title_text": "How boring was question 2?", "type": "text"}]}
+##match_string {"next_questions": [{"id": "password2", "name": "question3", "title": "How boring was question 1?", "title_text": "How boring was question 2?", "type": "TEXT"}]}
 match_string "password2"
 #
 ## Make sure answer ends up in file
@@ -70,7 +70,7 @@ endofsession
 request 200 addanswer?sessionid=$SESSION&answer=password2:myPaSSw0rD:0:0:0:0:0:0:0
 #
 ## Check that we are offered the next question to answer
-##match_string {"next_questions": [{"id": "beforeStartingSurvey", "name": "question3", "title": "How boring was question 1?", "title_text": "How boring was question 2?", "type": "text"}]}
+##match_string {"next_questions": [{"id": "beforeStartingSurvey", "name": "question3", "title": "How boring was question 1?", "title_text": "How boring was question 2?", "type": "TEXT"}]}
 match_string "beforeStartingSurvey"
 #
 ## Make sure answer ends up in file

--- a/backend/tests/005_surveyResultsVerification.test
+++ b/backend/tests/005_surveyResultsVerification.test
@@ -39,7 +39,7 @@ endofsession
 request 200 addanswer?sessionid=$SESSION&answer=email:test.email@domain.com:0:0:0:0:0:0:0
 
 # Check that we are offered the next question to answer
-#match_string {"next_questions": [{"id": "password1", "name": "question2", "title": "What is the answer to question 1?", "title_text": "What is the answer to question 2?", "type": "text"}]}
+#match_string {"next_questions": [{"id": "password1", "name": "question2", "title": "What is the answer to question 1?", "title_text": "What is the answer to question 2?", "type": "TEXT"}]}
 match_string "password1"
 
 # Make sure answer ends up in file
@@ -51,7 +51,7 @@ endofsession
 request 200 addanswer?sessionid=$SESSION&answer=password1:myPaSSw0rD:0:0:0:0:0:0:0
 
 # Check that we are offered the next question to answer
-#match_string {"next_questions": [{"id": "question3", "name": "question3", "title": "How boring was question 1?", "title_text": "How boring was question 2?", "type": "text"}]}
+#match_string {"next_questions": [{"id": "question3", "name": "question3", "title": "How boring was question 1?", "title_text": "How boring was question 2?", "type": "TEXT"}]}
 match_string "password2"
 
 # Make sure answer ends up in file
@@ -64,7 +64,7 @@ endofsession
 request 200 addanswer?sessionid=$SESSION&answer=password2:myPaSSw0rD:0:0:0:0:0:0:0
 
 # Check that we are offered the next question to answer
-#match_string {"next_questions": [{"id": "question3", "name": "question3", "title": "How boring was question 1?", "title_text": "How boring was question 2?", "type": "text"}]}
+#match_string {"next_questions": [{"id": "question3", "name": "question3", "title": "How boring was question 1?", "title_text": "How boring was question 2?", "type": "TEXT"}]}
 match_string "beforeStartingSurvey"
 
 # Make sure answer ends up in file

--- a/backend/tests/006_testShouldVerifyDefinitions.test
+++ b/backend/tests/006_testShouldVerifyDefinitions.test
@@ -33,7 +33,7 @@ endofsession
 request 200 addanswer?sessionid=$SESSION&answer=email:test.email@domain.com:0:0:0:0:0:0:0
 
 # Check that we are offered the next question to answer
-#match_string {"next_questions": [{"id": "password1", "name": "question2", "title": "What is the answer to question 1?", "title_text": "What is the answer to question 2?", "type": "text"}]}
+#match_string {"next_questions": [{"id": "password1", "name": "question2", "title": "What is the answer to question 1?", "title_text": "What is the answer to question 2?", "type": "TEXT"}]}
 match_string "password1"
 
 # Make sure answer ends up in file

--- a/backend/tests/007_testShouldVerifyDefinitions.test
+++ b/backend/tests/007_testShouldVerifyDefinitions.test
@@ -33,7 +33,7 @@ endofsession
 request 200 addanswer?sessionid=$SESSION&answer=email:test.email@domain.com:0:0:0:0:0:0:0
 
 # Check that we are offered the next question to answer
-#match_string {"next_questions": [{"id": "password1", "name": "question2", "title": "What is the answer to question 1?", "title_text": "What is the answer to question 2?", "type": "text"}]}
+#match_string {"next_questions": [{"id": "password1", "name": "question2", "title": "What is the answer to question 1?", "title_text": "What is the answer to question 2?", "type": "TEXT"}]}
 match_string "password1"
 
 # Make sure answer ends up in file

--- a/backend/tests/008_testShouldVerifyDefinitions.test
+++ b/backend/tests/008_testShouldVerifyDefinitions.test
@@ -32,7 +32,7 @@ endofsession
 request 200 addanswer?sessionid=$SESSION&answer=email:test.email@domain.com:0:0:0:0:0:0:0
 
 # Check that we are offered the next question to answer
-#match_string {"next_questions": [{"id": "password1", "name": "question2", "title": "What is the answer to question 1?", "title_text": "What is the answer to question 2?", "type": "text"}]}
+#match_string {"next_questions": [{"id": "password1", "name": "question2", "title": "What is the answer to question 1?", "title_text": "What is the answer to question 2?", "type": "TEXT"}]}
 match_string 'password1'
 
 # Make sure answer ends up in file

--- a/backend/tests/009_testCheckRecordedData.test
+++ b/backend/tests/009_testCheckRecordedData.test
@@ -35,7 +35,7 @@ endofsession
 request 200 addanswer?sessionid=$SESSION&answer=email:test.email@domain.com:0:0:0:0:0:0:0
 
 # Check that we are offered the next question to answer
-#match_string {"next_questions": [{"id": "password1", "name": "question2", "title": "What is the answer to question 1?", "title_text": "What is the answer to question 2?", "type": "text"}]}
+#match_string {"next_questions": [{"id": "password1", "name": "question2", "title": "What is the answer to question 1?", "title_text": "What is the answer to question 2?", "type": "TEXT"}]}
 match_string 'password1'
 
 # Make sure answer ends up in file

--- a/backend/tests/nextquestion1.test
+++ b/backend/tests/nextquestion1.test
@@ -22,5 +22,5 @@ endofsession
 
 # Ask for next question
 request 200 nextquestion?sessionid=$SESSION
-match_string {"next_questions": [{"id": "multichoice", "name": "multichoice", "title": "Select one of the following", "title_text": "Select one of the following", "type": "radiogroup", "choices": ["Yes", "No", "", "Maybe"]}]}
+match_string {"next_questions": [{"id": "multichoice", "name": "multichoice", "title": "Select one of the following", "title_text": "Select one of the following", "type": "MULTICHOICE", "choices": ["Yes", "No", "", "Maybe"]}]}
 

--- a/backend/tests/nextquestionagain.test
+++ b/backend/tests/nextquestionagain.test
@@ -24,5 +24,5 @@ endofsession
 for i = 1 to 10
 # Ask for next question
 request 200 nextquestion?sessionid=$SESSION
-match_string {"next_questions": [{"id": "multichoice", "name": "multichoice", "title": "Select one of the following", "title_text": "Select one of the following", "type": "radiogroup", "choices": ["Yes", "No", "", "Maybe"]}]}
+match_string {"next_questions": [{"id": "multichoice", "name": "multichoice", "title": "Select one of the following", "title_text": "Select one of the following", "type": "MULTICHOICE", "choices": ["Yes", "No", "", "Maybe"]}]}
 next

--- a/backend/tests/nextquestionpython.test
+++ b/backend/tests/nextquestionpython.test
@@ -31,5 +31,5 @@ endofsession
 
 # Ask for next question
 request 200 nextquestion?sessionid=$SESSION
-match_string {"next_questions": [{"id": "question2", "name": "question2", "title": "How boring was question 1?", "title_text": "How boring was question 1?", "type": "text"}]}
+match_string {"next_questions": [{"id": "question2", "name": "question2", "title": "How boring was question 1?", "title_text": "How boring was question 1?", "type": "TEXT"}]}
 

--- a/backend/tests/sequencedanswering.test
+++ b/backend/tests/sequencedanswering.test
@@ -23,7 +23,7 @@ endofsession
 request 200 addanswer?sessionid=$SESSION&answer=question1:Hello+World:0:0:0:0:0:0:0
 
 # Check that we are offered the next question to answer
-match_string {"next_questions": [{"id": "question2", "name": "question2", "title": "What is the answer to question 1?", "title_text": "What is the answer to question 2?", "type": "text"}]}
+match_string {"next_questions": [{"id": "question2", "name": "question2", "title": "What is the answer to question 1?", "title_text": "What is the answer to question 2?", "type": "TEXT"}]}
 
 # Make sure answer ends up in file
 verify_session
@@ -34,7 +34,7 @@ endofsession
 request 200 addanswer?sessionid=$SESSION&answer=question2:Another+answer:0:0:0:0:0:0:0
 
 # Check that we are offered the next question to answer
-match_string {"next_questions": [{"id": "question3", "name": "question3", "title": "How boring was question 1?", "title_text": "How boring was question 2?", "type": "text"}]}
+match_string {"next_questions": [{"id": "question3", "name": "question3", "title": "How boring was question 1?", "title_text": "How boring was question 2?", "type": "TEXT"}]}
 
 # Make sure answer ends up in file
 verify_session

--- a/backend/tests/simplestFullLogic.test
+++ b/backend/tests/simplestFullLogic.test
@@ -22,5 +22,5 @@ endofsession
 
 # Ask for next question
 request 200 nextquestion?sessionid=$SESSION
-match_string {"next_questions": [{"id": "multichoice", "name": "multichoice", "title": "Select one of the following", "title_text": "Select one of the following", "type": "radiogroup", "choices": ["Yes", "No", "", "Maybe"]}]}
+match_string {"next_questions": [{"id": "multichoice", "name": "multichoice", "title": "Select one of the following", "title_text": "Select one of the following", "type": "MULTICHOICE", "choices": ["Yes", "No", "", "Maybe"]}]}
 

--- a/front/src/__tests__/payload-serializer.test.js
+++ b/front/src/__tests__/payload-serializer.test.js
@@ -1,4 +1,4 @@
-import { serializeAnswer } from '../payload-serializer';
+import { serializeAnswer, serializeAnswerValue } from '../payload-serializer';
 
 /*
  * @see backend/src/question_types.c
@@ -14,48 +14,112 @@ import { serializeAnswer } from '../payload-serializer';
  * DESERIALISE_INT(a->dst_delta);
  */
 
-describe('serialize to CSV row', () => {
+describe('serializeAnswer: to CSV row', () => {
+
+    let a;
 
     test('type: text', () => {
         //positive
-        expect(serializeAnswer('text', 'T', 'text')).toBe('text:T:0:0:0:0:0:0:0');
-        expect(serializeAnswer('text', 1.24, 'text')).toBe('text:1.24:0:0:0:0:0:0:0');
-        expect(serializeAnswer('text', new String('T'), 'text')).toBe('text:\"T\":0:0:0:0:0:0:0');
+        expect(serializeAnswer('textid', { text: 'T' })).toBe('textid:T:0:0:0:0:0:0:0');
+        expect(serializeAnswer('textid', { text: 1.24 })).toBe('textid:1.24:0:0:0:0:0:0:0');
+
+        expect(serializeAnswer('textid', { text: new String('T') })).toBe('textid:\"T\":0:0:0:0:0:0:0');
         // tests json and escaping quotes and colons
-        expect(serializeAnswer('text', '{ "isJSON": true }', 'text')).toBe('text:{ \"isJSON\"\: true }:0:0:0:0:0:0:0');
-        expect(serializeAnswer('text', "Tom's", 'text')).toBe("text:Tom\'s:0:0:0:0:0:0:0");
-        expect(serializeAnswer('text', '  trim text  ', 'text')).toBe('text:trim text:0:0:0:0:0:0:0');
+        expect(serializeAnswer('textid', { text: '{ "isJSON": true }' })).toBe('textid:{ \"isJSON\"\: true }:0:0:0:0:0:0:0');
+        expect(serializeAnswer('textid', { text: "Tom's" })).toBe("textid:Tom\'s:0:0:0:0:0:0:0");
+        expect(serializeAnswer('textid', { text: '  trim text  ' })).toBe('textid:trim text:0:0:0:0:0:0:0');
         // negative
-        expect(serializeAnswer('text', '', 'text')).toBeInstanceOf(Error);
-        expect(serializeAnswer('text', null, 'text')).toBeInstanceOf(Error);
-        expect(serializeAnswer('text', undefined, 'text')).toBeInstanceOf(Error);
-        expect(serializeAnswer('text', Symbol(1), 'text')).toBeInstanceOf(Error);
+        expect(serializeAnswer('textid')).toBeInstanceOf(Error);
+        expect(serializeAnswer('textid', null)).toBeInstanceOf(Error);
+        expect(serializeAnswer('textid', 'invalid')).toBeInstanceOf(Error);
+
+        expect(serializeAnswer('textid', { text: '' })).toBeInstanceOf(Error);
+        expect(serializeAnswer('textid', { text: null })).toBeInstanceOf(Error);
+        expect(serializeAnswer('textid', { text: undefined })).toBeInstanceOf(Error);
+        expect(serializeAnswer('textid', { text: Symbol(1) })).toBeInstanceOf(Error);
     });
 
     test('type: number', () => {
         //positive
-        expect(serializeAnswer('number', 0, 'number')).toBe('number::0:0:0:0:0:0:0');
-        expect(serializeAnswer('number', 1, 'number')).toBe('number::1:0:0:0:0:0:0');
-        expect(serializeAnswer('number', 0.1, 'number')).toBe('number::0.1:0:0:0:0:0:0');
-        expect(serializeAnswer('number', '123', 'number')).toBe('number::123:0:0:0:0:0:0');
-        expect(serializeAnswer('number', new Number(123), 'number')).toBe('number::123:0:0:0:0:0:0');
+        expect(serializeAnswer('numberid', { number: 0 })).toBe('numberid::0:0:0:0:0:0:0');
+        expect(serializeAnswer('numberid', { number: 1 })).toBe('numberid::1:0:0:0:0:0:0');
+        expect(serializeAnswer('numberid', { number: 0.1 })).toBe('numberid::0.1:0:0:0:0:0:0');
+        expect(serializeAnswer('numberid', { number: '123' })).toBe('numberid::123:0:0:0:0:0:0');
+        expect(serializeAnswer('numberid', { number: new Number(123) })).toBe('numberid::123:0:0:0:0:0:0');
         // negative
-        expect(serializeAnswer('number', NaN, 'number')).toBeInstanceOf(Error);
-        expect(serializeAnswer('number', Infinity, 'number')).toBeInstanceOf(Error);
-        expect(serializeAnswer('number', null, 'number')).toBeInstanceOf(Error);
-        expect(serializeAnswer('number', undefined, 'number')).toBeInstanceOf(Error);
-        expect(serializeAnswer('number', Symbol(1), 'number')).toBeInstanceOf(Error);
+        expect(serializeAnswer('numberid')).toBeInstanceOf(Error);
+        expect(serializeAnswer('numberid', null)).toBeInstanceOf(Error);
+        expect(serializeAnswer('numberid', 'invalid')).toBeInstanceOf(Error);
+
+        expect(serializeAnswer('numberid', { number: NaN })).toBeInstanceOf(Error);
+        expect(serializeAnswer('numberid', { number: Infinity, })).toBeInstanceOf(Error);
+        expect(serializeAnswer('numberid', { number: null, })).toBeInstanceOf(Error);
+        expect(serializeAnswer('numberid', { number: undefined, })).toBeInstanceOf(Error);
+        expect(serializeAnswer('numberid', { number: Symbol(1), })).toBeInstanceOf(Error);
     });
 
     test('type: geolocation', () => {
         // positive
-        expect(serializeAnswer('id', '0,0', 'geolocation')).toBe('id::0:0:0:0:0:0:0');
-        expect(serializeAnswer('id', '1.0,0.1', 'geolocation')).toBe('id::0:1:0.1:0:0:0:0');
-        expect(serializeAnswer('id', '  1.0,  0.1  ', 'geolocation')).toBe('id::0:1:0.1:0:0:0:0');
+        expect(serializeAnswer('geolocationid', { geolocation: '0,0' })).toBe('geolocationid::0:0:0:0:0:0:0');
+        expect(serializeAnswer('geolocationid', { geolocation: '1.0,0.1' })).toBe('geolocationid::0:1:0.1:0:0:0:0');
+        expect(serializeAnswer('geolocationid', { geolocation: '  1.0,  0.1  ' })).toBe('geolocationid::0:1:0.1:0:0:0:0');
         // negative
-        expect(serializeAnswer('number', '0.2,string', 'geolocation')).toBeInstanceOf(Error);
-        expect(serializeAnswer('number', 'string,0.2', 'geolocation')).toBeInstanceOf(Error);
-        expect(serializeAnswer('number', NaN, 'geolocation')).toBeInstanceOf(Error);
+        expect(serializeAnswer('geolocationid')).toBeInstanceOf(Error);
+        expect(serializeAnswer('geolocationid', null)).toBeInstanceOf(Error);
+        expect(serializeAnswer('geolocationid', 'invalid')).toBeInstanceOf(Error);
+
+        expect(serializeAnswer('geolocationid', { geolocation: '0.2,string' })).toBeInstanceOf(Error);
+        expect(serializeAnswer('geolocationid', { geolocation: 'string,0.2' })).toBeInstanceOf(Error);
+        expect(serializeAnswer('geolocationid', { geolocation: NaN })).toBeInstanceOf(Error);
+    });
+
+    xtest('type: datetime', () => {
+    });
+
+});
+
+describe('serializeAnswerValue: to CSV row', () => {
+
+    test('type: text', () => {
+        //positive
+        expect(serializeAnswerValue('textid', 'T', 'text')).toBe('textid:T:0:0:0:0:0:0:0');
+        expect(serializeAnswerValue('textid', 1.24, 'text')).toBe('textid:1.24:0:0:0:0:0:0:0');
+        expect(serializeAnswerValue('textid', new String('T'), 'text')).toBe('textid:\"T\":0:0:0:0:0:0:0');
+        // tests json and escaping quotes and colons
+        expect(serializeAnswerValue('textid', '{ "isJSON": true }', 'text')).toBe('textid:{ \"isJSON\"\: true }:0:0:0:0:0:0:0');
+        expect(serializeAnswerValue('textid', "Tom's", 'text')).toBe("textid:Tom\'s:0:0:0:0:0:0:0");
+        expect(serializeAnswerValue('textid', '  trim text  ', 'text')).toBe('textid:trim text:0:0:0:0:0:0:0');
+        // negative
+        expect(serializeAnswerValue('textid', '', 'text')).toBeInstanceOf(Error);
+        expect(serializeAnswerValue('textid', null, 'text')).toBeInstanceOf(Error);
+        expect(serializeAnswerValue('textid', undefined, 'text')).toBeInstanceOf(Error);
+        expect(serializeAnswerValue('textid', Symbol(1), 'text')).toBeInstanceOf(Error);
+    });
+
+    test('type: number', () => {
+        //positive
+        expect(serializeAnswerValue('numberid', 0, 'number')).toBe('numberid::0:0:0:0:0:0:0');
+        expect(serializeAnswerValue('numberid', 1, 'number')).toBe('numberid::1:0:0:0:0:0:0');
+        expect(serializeAnswerValue('numberid', 0.1, 'number')).toBe('numberid::0.1:0:0:0:0:0:0');
+        expect(serializeAnswerValue('numberid', '123', 'number')).toBe('numberid::123:0:0:0:0:0:0');
+        expect(serializeAnswerValue('numberid', new Number(123), 'number')).toBe('numberid::123:0:0:0:0:0:0');
+        // negative
+        expect(serializeAnswerValue('numberid', NaN, 'number')).toBeInstanceOf(Error);
+        expect(serializeAnswerValue('numberid', Infinity, 'number')).toBeInstanceOf(Error);
+        expect(serializeAnswerValue('numberid', null, 'number')).toBeInstanceOf(Error);
+        expect(serializeAnswerValue('numberid', undefined, 'number')).toBeInstanceOf(Error);
+        expect(serializeAnswerValue('numberid', Symbol(1), 'number')).toBeInstanceOf(Error);
+    });
+
+    test('type: geolocation', () => {
+        // positive
+        expect(serializeAnswerValue('geolocationid', '0,0', 'geolocation')).toBe('geolocationid::0:0:0:0:0:0:0');
+        expect(serializeAnswerValue('geolocationid', '1.0,0.1', 'geolocation')).toBe('geolocationid::0:1:0.1:0:0:0:0');
+        expect(serializeAnswerValue('geolocationid', '  1.0,  0.1  ', 'geolocation')).toBe('geolocationid::0:1:0.1:0:0:0:0');
+        // negative
+        expect(serializeAnswerValue('numberid', '0.2,string', 'geolocation')).toBeInstanceOf(Error);
+        expect(serializeAnswerValue('numberid', 'string,0.2', 'geolocation')).toBeInstanceOf(Error);
+        expect(serializeAnswerValue('numberid', NaN, 'geolocation')).toBeInstanceOf(Error);
     });
 
     xtest('type: datetime', () => {

--- a/front/src/components/form/GeoLocation.jsx
+++ b/front/src/components/form/GeoLocation.jsx
@@ -61,6 +61,8 @@ class GeoLocation extends Component {
 
     fetchLocation() {
         const { question } = this.props;
+        const { type } = question;
+
         fetchLocation()
         .then((coords) => {
             const value = latlonString(coords);
@@ -69,7 +71,9 @@ class GeoLocation extends Component {
                 error: null,
             });
             // send immediately to survey
-            this.props.handleChange(this.state.value, question);
+            this.props.handleChange({
+                [type]: this.state.value,
+            }, question);
         })
         .catch(err => this.setState({
             value: '',

--- a/front/src/components/form/PeriodRange.jsx
+++ b/front/src/components/form/PeriodRange.jsx
@@ -4,13 +4,14 @@ import PropTypes from 'prop-types';
 import InputRange from 'react-input-range';
 import './PeriodRange.scss';
 
-const d2sec = 86400; // 24 hours
-const h2sec = 3600;
+const DaySec = 86400; // 24 hours
 
+// bg gradient
 const dark = '#212077';
 const light = '#ffc107';
 const gradient = `linear-gradient(to right, ${dark} 15%, ${light} 30%, ${light} 70%, ${dark} 85%)`;
 
+// styles
 const wrapperStyle = {
     background: gradient,
     padding: '1rem',
@@ -58,29 +59,34 @@ class PeriodRange extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            time_begin: 0,
-            time_end: 0,
+            value: {
+                min:  9 * 3600,
+                max: 20 * 3600
+            }
         };
     }
 
     handleChange(value) {
         const { question } = this.props;
+        const { type } = question;
 
-        const updated = this.state;
-        updated['time_begin'] = value.min;
-        updated['time_end'] = value.max;
+        const model = {
+            time_begin: value.min,
+            time_end: value.max,
+        };
 
-        this.setState(updated);
+        this.props.handleChange({
+            [type]: model,
+        }, question);
 
         // TODO validate here?
-        this.props.handleChange(updated, question);
+        this.props.handleChange(model, question);
     }
 
     render() {
-        const { question, timeBeginLabel, timeEndLabel } = this.props;
-        const { time_begin, time_end } = this.state;
+        const { question } = this.props;
+        const { value } = this.state;
 
-        const domain = [0, d2sec];
         return (
             <div className="form-group">
             <div style={ wrapperStyle }>
@@ -91,11 +97,10 @@ class PeriodRange extends Component {
                 </div>
                 <InputRange
                     minValue={ 0 }
-                    maxValue={ d2sec }
-                    defaultValue={ [1000, 3000] }
-                    value={ { min: time_begin, max: time_end } }
+                    maxValue={ DaySec }
+                    value={ value }
                     onChange={ this.handleChange.bind(this) }
-                    formatLabel={ value => prettyHours(value) }
+                    formatLabel={ val => prettyHours(val) }
                 />
             </div>
             </div>

--- a/front/src/components/form/PeriodRange.scss
+++ b/front/src/components/form/PeriodRange.scss
@@ -1,3 +1,5 @@
+////  react-input-range overwrites
+
 $input-range-primary-color : #ffffff;
 
 $input-range-slider-background: #28a745;

--- a/front/src/components/form/RadioGroup.jsx
+++ b/front/src/components/form/RadioGroup.jsx
@@ -5,19 +5,23 @@ class RadioGroup extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            value: props.question.defaultValue || '',
+            value: '',
         };
     }
 
     handleChange(e) {
         const { value } = e.target;
+
         const { question } = this.props;
+        const { type } = question;
 
         this.setState({
             value: value
         });
 
-        this.props.handleChange(value, question);
+        this.props.handleChange({
+            [type]: this.state.value,
+        }, question);
     }
 
     render() {

--- a/front/src/components/form/Select.jsx
+++ b/front/src/components/form/Select.jsx
@@ -5,18 +5,22 @@ class Select extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            value: props.question.defaultValue || '',
+            value: '',
         };
     }
 
     handleChange(e) {
         const { value } = e.target;
         const { question } = this.props;
+        const { type } = question;
 
         this.setState({
             value: value
         });
-        this.props.handleChange(value, question);
+
+        this.props.handleChange({
+            [type]: value,
+        }, question);
     }
 
     render() {
@@ -26,6 +30,7 @@ class Select extends Component {
             <div className="form-group">
                 <p><strong> { question.title_text }</strong></p>
                 <select
+                    onChange={ this.handleChange.bind(this) }
                     id={ question.id }
                     name={ question.name }
                     className="form-control">

--- a/front/src/components/form/TextInput.jsx
+++ b/front/src/components/form/TextInput.jsx
@@ -1,24 +1,46 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-const TextInput = function(props) {
-    const { question, handleChange, placeholder } = props;
-    return (
-        <div className="form-group">
-            <label htmlFor={ question.id }>{ question.title_text }</label>
-            <input
-                id={ question.id }
-                name={ question.name }
-                type="text"
-                className="form-control"
-                placeholder={ placeholder }
-                autoComplete="off"
-                onChange={ (e) => handleChange(e.target.value, question) }
-                defaultValue={ question.defaultValue || null }
-            />
-        </div>
-    );
-};
+class TextInput extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: '',
+        };
+    }
+
+    handleChange(e) {
+        const { value } = e.target;
+        const { question } = this.props;
+        const { type } = question;
+
+        this.setState({
+            value: value
+        });
+
+        this.props.handleChange({
+            [type]: value,
+        }, question);
+    }
+
+    render() {
+        const { question, placeholder } = this.props;
+        return (
+            <div className="form-group">
+                <label htmlFor={ question.id }>{ question.title_text }</label>
+                <input
+                    id={ question.id }
+                    name={ question.name }
+                    type="text"
+                    className="form-control"
+                    placeholder={ placeholder }
+                    autoComplete="off"
+                    onChange={ this.handleChange.bind(this) }
+                />
+            </div>
+        );
+    }
+}
 
 TextInput.defaultProps = {
     placeholder: null,
@@ -32,8 +54,6 @@ TextInput.propTypes = {
         title: PropTypes.string.isRequired,
         title_text: PropTypes.string.isRequired,
         type: PropTypes.string.isRequired,
-
-        defaultValue: PropTypes.string,
     }).isRequired,
     placeholder: PropTypes.string,
 };


### PR DESCRIPTION
I suggest removing the extra mapping of question types in [fcgi_nextquestion], i.e. `MULTICHOICE` maps to '`radiobuttons` etc.

I suppose it was done to accommodate the front end. If that is the case the this is not required anymore

Unless I am overseeing something significant then this extra mapping is unnecessary and just adds an extra layer of abstraction and things who could break. Also, it makes fastcgi reasoning about the frontend.

On my side I use the types to render form elements and map input values them to the answer csv model `<uid>:<text>:<value>:<lat>:<lon>:<time_begin>:<time_end>:<time_zone_delta>:<dst_delta>` 

**changes: **
- fcgimain.c (fn fcgi_nextquestion())
- tests/

backend tests are passing

```bash
$ sudo ./runtests 
clang -Wall -O3 -g -Iinclude `/usr/bin/python3.7-config --includes` -Ikcgi -c src/fcgimain.c -o src/fcgimain.o
clang -Wall -O3 -g -Iinclude `/usr/bin/python3.7-config --includes` -Ikcgi -o surveyfcgi src/errorlog.o src/sha1.o src/paths.o src/log.o src/sessions.o src/nextquestion.o src/serialisers.o src/code_instrumentation.o src/question_types.o src/fcgimain.o kcgi/libkcgihtml.a kcgi/libkcgi.a kcgi/libkcgijson.a `/usr/bin/python3.7-config --libs --ldflags` kcgi/libkcgihtml.a kcgi/libkcgi.a kcgi/libkcgijson.a -lz
make: 'test_runner' is up to date.
Using /tmp/surveytestrunner.1544072822.26400 as test directory

[PASS]  001_nextquestionpythonActualLogic.test : Python implementation of nextquestion can be used
[DIED]  002_shouldFAIL_pythonIndentError.test : Python implementation of nextquestion can be used
[PASS]  003_outputFromPythonShouldBeSameAsFromC.test : Python implementation of nextquestion can be used
[PASS]  004_pythonAlgSequencedAnswer.test : Answer questions, and obtain a sensible next question each time
[PASS]  005_surveyResultsVerification.test : Answer questions, and obtain a sensible next question each time
[PASS]  006_testShouldVerifyDefinitions.test : test infrastructure shuold check syntax in test file (in this case, defined survey has wrong name)
[PASS]  007_testShouldVerifyDefinitions.test : test infrastructure shuold check syntax in test file (in this case, endOfSurvey line is missing) 

Could not parse description line of test.

Could not parse description line of test.
[PASS]  accesstest.test : FastCGI binary can access required paths
[PASS]  answernonexistantquestion.test : Answer a question in a survey
[PASS]  answerquestion.test : Answer a question in a survey
[PASS]  createsession.test : Create a new session
[PASS]  nextquestion1.test : nextquestion returns something
[PASS]  nextquestionagain.test : nextquestion returns something if called more than once
[PASS]  nextquestionpython.test : Python implementation of nextquestion can be used
[PASS]  runanalysis.test : Run post-survey analysis
[PASS]  sequencedanswering.test : Answer questions, and obtain a sensible next question each time
[PASS]  simplestFullLogic.test : nextquestion returns something else
Cleaning up...
Stop lighttpd service...
Summary: 16/19 tests passed (0 failed, 0 errors, 1 fatalities during tests)
```