### PR TITLE
backend: test_runner request, options for method and data

### DIFF
--- a/backend/src/test_runner.c
+++ b/backend/src/test_runner.c
@@ -602,7 +602,7 @@ int run_test(char *dir, char *test_file)
 
   	// adds extended request options (request method and request data)
     	char data[65536] = { '\0' };
-    	char method[10] = "GET";
+    	char method[65536] = "GET";
    	sscanf(line,"request %d %s %s %s", &expected_result, url, method, data);
 
 	int o=0;

--- a/backend/src/test_runner.c
+++ b/backend/src/test_runner.c
@@ -600,6 +600,11 @@ int run_test(char *dir, char *test_file)
 	char cmd[65536];
 	char url_sub[65536];
 
+  	// adds extended request options (request method and request data)
+    	char data[65536] = { '\0' };
+    	char method[10] = "GET";
+   	sscanf(line,"request %d %s %s %s", &expected_result, url, method, data);
+
 	int o=0;
 	for(int i=0;url[i];i++) {
 	  if (url[i]!='$') url_sub[o++]=url[i];
@@ -637,8 +642,10 @@ int run_test(char *dir, char *test_file)
 	  goto fatal;	      
 	}
 	
-	snprintf(cmd,65536,"curl -s -w \"HTTPRESULT=%%{http_code}\" -o %s/request.out \"http://localhost/surveyapi/%s\" > %s/request.code",
-		 dir,url_sub,dir);
+        snprintf(cmd, 65536,
+            "curl -X %s -s -w \"HTTPRESULT=%%{http_code}\" %s%s -o %s/request.out \"http://localhost/surveyapi/%s\" > %s/request.code",
+            method, ((data[0] == '\0') ? "" : "-d "), data, dir, url_sub, dir);
+
 	tdelta=gettime_us()-start_time; tdelta/=1000;
 	fprintf(log,"T+%4.3fms : HTTP API request command: '%s'\n",tdelta,cmd);
 	int shell_result=system(cmd);

--- a/backend/tests/POST-answerquestion.test
+++ b/backend/tests/POST-answerquestion.test
@@ -1,0 +1,31 @@
+description POST requests - open session and answer a question
+
+# Create a dummy survey
+definesurvey postrequests
+version 1
+Silly test survey updated
+multichoice:Select one of the following:Select one of the following:MULTICHOICE:0::-1:-1:-1:3:Yes,No,Maybe:
+question1:What is the answer to question 1?:What is the answer to question 1?:TEXT:0:I don't know:-1:-1:0:0::
+endofsurvey
+
+# Request creation of a  new session
+request 200 newsession POST "surveyid=postrequests"
+match_string 0a7caf5b02adad7583c7bfae30f6f119cb3581cc
+
+# Get the session ID that newsession should have returned
+extract_sessionid
+
+# Check that we have an empty session file created
+verify_session
+postrequests/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
+endofsession
+
+request 200 addanswer POST "sessionid=$SESSION&answer=question1:Hello+World:0:0:0:0:0:0:0:"
+
+# Check that we are offered the next question to answer
+
+# Make sure answer ends up in file
+verify_session
+postrequests/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
+question1:Hello World:0:0:0:0:0:0:0:
+endofsession


### PR DESCRIPTION
see #136 

currently, the `request` directive allows only for GET requests. 

task: Extend the directive to allow to define the request method and add an (urlencoded) data body. the format should be backwards compatible in order to avoid changing all existing tests

current format (still working): 
```bash
# request [STATUSCODE] [URL]
request 200 addanswer?sessionid=$SESSION&answer=question1:Hello+World:0:0:0:0:0:0:0:
```
extended format: 

```bash
# request [STATUSCODE] [URL] [METHOD] "[DATA]"
request 200 addanswer POST "sessionid=$SESSION&answer=question1:Hello+World:0:0:0:0:0:0:0:"
```