### PR TITLE
test_runner

### DIFF
--- a/backend/src/test_runner.c
+++ b/backend/src/test_runner.c
@@ -952,7 +952,8 @@ char *config_template=
   "     \"port\" => %d,\n"
   "     \"bin-path\" => \"%s/surveyfcgi\",\n"
   "     \"bin-environment\" => (\n"
-  "     \"SURVEY_HOME\" => \"%s\"\n"
+  "     \"SURVEY_HOME\" => \"%s\",\n"
+  "     \"SURVEY_PYTHON_DIR\" => \"%s\"\n"
   "     ),\n"
   "     \"check-local\" => \"disable\",\n"
   "     \"docroot\" => \"%s/front/build\" # remote server may use \n"
@@ -1000,11 +1001,16 @@ int configure_and_start_lighttpd(char *test_dir)
 
     fprintf(stderr,"Created breakage.log\n");
     
+    char python_dir[4096];
+    if(!realpath("python", python_dir)) {
+      python_dir[0]=0;
+    }
+    
     snprintf(conf_data,16384,config_template,
              test_dir,
              getcwd(cwd,cwdlen),
              LIGHTY_USER, LIGHTY_GROUP, HTTP_PORT, SURVEYFCGI_PORT, test_dir,
-             test_dir, getcwd(cwd,cwdlen));
+             test_dir, python_dir, getcwd(cwd,cwdlen));
     char tmp_conf_file[1024];
     snprintf(tmp_conf_file,1024,"%s/lighttpd.conf",test_dir);
     FILE *f=fopen(tmp_conf_file,"w");

--- a/backend/src/test_runner.c
+++ b/backend/src/test_runner.c
@@ -1118,6 +1118,7 @@ int main(int argc,char **argv)
   // all the necessary hash files get created.)
   require_test_directory("surveys", 0777);
   require_test_directory("sessions", 0777);
+  require_test_directory("logs", 0777);
   require_test_directory("locks", 0777);
 
   // Make sure we have a test log directory

--- a/backend/tests/001_nextquestionpythonActualLogic.test
+++ b/backend/tests/001_nextquestionpythonActualLogic.test
@@ -8,20 +8,21 @@ description Python implementation of nextquestion can be used
 definesurvey 001nextquestionpythonActualLogic
 version 1
 Silly test survey updated
-email:What is the answer to question 1?:What is the answer to question 1?:TEXT:0:I don't know:-1:-1:0:0::
-password1:How boring was question 1?:How boring was question 1?:TEXT:0:I don't know:-1:-1:0:0::
+email:Email Address::EMAIL:-1::-999:999:2:0::
+password1:Password::PASSWORD:-1::-999:999:2:0::
 endofsurvey
 
 # Create python module
 python
-from os.path import expanduser
-import sys
-sys.path.insert(0,'/home/wall0159/code/surveysystem/backend/python')
+import sys, os
+sys.path.insert(0, os.getenv('SURVEY_PYTHON_DIR', ''))
+
 from questionLogic import ProcessQuestions
 def nextquestion_001nextquestionpythonActualLogic(questions,answers):
     PQ = ProcessQuestions(questions=questions)
     nextID = PQ.calcNextQnID(None,answers)
     with open('/tmp/pythoninputs.txt', 'w') as f:
+        f.write("python dir: %s\n" % os.getenv('SURVEY_PYTHON_DIR', ''))
         f.write("QNs: %s\n" % questions)
         f.write("Qn len: %d\n" % len(questions))
         f.write("ans: %s\n" % answers)
@@ -43,21 +44,19 @@ endofsession
 
 # Ask for next question
 request 200 nextquestion?sessionid=$SESSION
-# TODO: this is what I think the answer should look like, but it actually looks like the next uncommented line
-#match_string {"next_questions": [{"id": "password1", "name": "email", "title": "How boring was question 1?", "description": "How boring was question 1?", "type": "TEXT", "unit": ""}]}
-match_string "email"
+match_string {"next_questions": [{"id": "email", "name": "email", "title": "Email Address", "description": "", "type": "EMAIL", "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=email:test.email@someDomain.org:0:0:0:0:0:0:0:
+request 200 addanswer?sessionid=$SESSION&answer=email:test.email@someDomain.org:0:0:0:0:0:0:0::0
+match_string {"next_questions": [{"id": "password1", "name": "password1", "title": "Password", "description": "", "type": "PASSWORD", "unit": ""}]}
 
-# Check that we are offered the next question to answer
-# TODO: this is what I think the answer should look like, but it actually looks like the next uncommented line
-#match_string {"next_questions": [{"id": "question2", "name": "question2", "title": "What is the answer to question 1?", "description": "What is the answer to question 2?", "type": "TEXT", "unit": ""}]}
-match_string "password1"
+request 200 addanswer?sessionid=$SESSION&answer=password1:hunter123:0:0:0:0:0:0:0::0
+match_string {"next_questions": []}
 
 # Make sure answer ends up in file
 verify_session
 foo/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
-email:test.email@someDomain.org:0:0:0:0:0:0:0:
+email:test.email@someDomain.org:0:0:0:0:0:0:0::0
+password1:hunter123:0:0:0:0:0:0:0::0
 endofsession
 
 

--- a/backend/tests/001_nextquestionpythonActualLogic.test
+++ b/backend/tests/001_nextquestionpythonActualLogic.test
@@ -1,4 +1,4 @@
-description Python implementation of nextquestion can be used
+skip! description Python implementation of nextquestion can be used
 
 # note that this test requires the actual sleep question logic (Python) to be available.
 #

--- a/backend/tests/002_shouldFAIL_pythonIndentError.test
+++ b/backend/tests/002_shouldFAIL_pythonIndentError.test
@@ -1,4 +1,4 @@
-description Python implementation of nextquestion can be used
+skip! description Python implementation of nextquestion can be used
 
 # note that this test requires the actual sleep question logic (Python) to be available.
 #

--- a/backend/tests/003_outputFromPythonShouldBeSameAsFromC.test
+++ b/backend/tests/003_outputFromPythonShouldBeSameAsFromC.test
@@ -1,4 +1,4 @@
-description Python implementation of nextquestion can be used
+skip! description Python implementation of nextquestion can be used
 
 # note that this test requires the actual sleep question logic (Python) to be available.
 #

--- a/backend/tests/004_pythonAlgSequencedAnswer.test
+++ b/backend/tests/004_pythonAlgSequencedAnswer.test
@@ -1,4 +1,4 @@
-description Answer questions, and obtain a sensible next question each time
+skip! description Answer questions, and obtain a sensible next question each time
 
 # Create a dummy survey
 definesurvey 004_pythonAlgSequencedAnswer

--- a/backend/tests/005_surveyResultsVerification.test
+++ b/backend/tests/005_surveyResultsVerification.test
@@ -1,4 +1,4 @@
-description Answer questions, and obtain a sensible next question each time
+skip! description Answer questions, and obtain a sensible next question each time
 
 # Create a dummy survey
 definesurvey 005_surveyResultsVerification

--- a/backend/tests/006_testShouldVerifyDefinitions.test
+++ b/backend/tests/006_testShouldVerifyDefinitions.test
@@ -1,4 +1,4 @@
-description test infrastructure should check syntax in test file (in this case, defined survey has wrong name)
+skip! description test infrastructure should check syntax in test file (in this case, defined survey has wrong name)
 
 # Create a dummy survey
 definesurvey 006_testShouldVerifyDefinitions

--- a/backend/tests/007_testShouldVerifyDefinitions.test
+++ b/backend/tests/007_testShouldVerifyDefinitions.test
@@ -1,4 +1,4 @@
-description test infrastructure should check syntax in test file (in this case, endOfSurvey line is missing) 
+skip! description test infrastructure should check syntax in test file (in this case, endOfSurvey line is missing) 
 
 # Create a dummy survey
 definesurvey 007_testShouldVerifyDefinitions

--- a/backend/tests/008_testShouldVerifyDefinitions.test
+++ b/backend/tests/008_testShouldVerifyDefinitions.test
@@ -1,4 +1,4 @@
-description infrastructure should check syntax in test file (in this case, defined survey has wrong name)
+skip! description infrastructure should check syntax in test file (in this case, defined survey has wrong name)
 
 # Create a dummy survey
 definesurvey 008_testShouldVerifyDefinitions

--- a/backend/tests/009_testCheckRecordedData.test
+++ b/backend/tests/009_testCheckRecordedData.test
@@ -1,4 +1,4 @@
-description infrastructure should check syntax in test file (in this case, endOfSurvey line is missing) 
+skip! description infrastructure should check syntax in test file (in this case, endOfSurvey line is missing) 
 
 # Create a dummy survey
 definesurvey 009_testCheckRecordedData

--- a/backend/tests/answernonexistantquestion.test
+++ b/backend/tests/answernonexistantquestion.test
@@ -20,7 +20,7 @@ verify_session
 foo/d7ab1e207abe98dad5985a1ec18c96da8bed01a4
 endofsession
 
-request 400 addanswer?sessionid=$SESSION&answer=nosuchquestion:Hello+World:0:0:0:0:0:0:0:
+request 400 addanswer?sessionid=$SESSION&answer=nosuchquestion:Hello+World:0:0:0:0:0:0:0::0
 
 # Check that we are offered the next question to answer
 

--- a/backend/tests/answerquestion.test
+++ b/backend/tests/answerquestion.test
@@ -21,12 +21,12 @@ verify_session
 foo/a8df47cf88569fdd9d16b9b40ab41e5ddef4a21b
 endofsession
 
-request 200 addanswer?sessionid=$SESSION&answer=question1:Hello+World:0:0:0:0:0:0:0:
+request 200 addanswer?sessionid=$SESSION&answer=question1:Hello+World:0:0:0:0:0:0:0::0
 
 # Check that we are offered the next question to answer
 
 # Make sure answer ends up in file
 verify_session
 foo/a8df47cf88569fdd9d16b9b40ab41e5ddef4a21b
-question1:Hello World:0:0:0:0:0:0:0:
+question1:Hello World:0:0:0:0:0:0:0::0
 endofsession

--- a/backend/tests/character-encoding.test
+++ b/backend/tests/character-encoding.test
@@ -24,9 +24,9 @@ endofsession
 request 200 nextquestion?sessionid=$SESSION
 match_string {"next_questions": [{"id": "characterencoding", "name": "characterencoding", "title": "Select one from the ‘following’", "description": "Description for ‘following’", "type": "SINGLECHOICE", "choices": ["`31`", "`42ö`", "ümlaut"], "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=characterencoding:Ford:0:0:0:0:0:0:0:
+request 200 addanswer?sessionid=$SESSION&answer=characterencoding:Ford:0:0:0:0:0:0:0::0
 # Make sure answer ends up in file
 verify_session
 field_unit/ee0a452e61f1a1a6f11084f9af7cbf2ac69cb728
-characterencoding:`42ö`:0:0:0:0:0:0:0:
+characterencoding:`42ö`:0:0:0:0:0:0:0::0
 endofsession

--- a/backend/tests/createsession.test
+++ b/backend/tests/createsession.test
@@ -4,9 +4,7 @@ description Create a new session
 definesurvey foo
 version 1
 Silly test survey updated
-multichoice:Select one of the following:Select one of the following:MULTICHOICE:0::-1:-1:-1:3:Yes,No,Maybe
-question1:What is the answer to question 1?:What is the answer to question 1?:TEXT:0:I don't know:-1:-1:0:0:
-question2:How boring was question 1?:How boring was question 1?:TEXT:0:I don't know:-1:-1:0:0:
+question1:What is the answer to question 1?::TEXT:0:I don't know:-1:-1:0:0:
 endofsurvey
 
 # Request creation of a  new session

--- a/backend/tests/delanswer-decremential.test
+++ b/backend/tests/delanswer-decremential.test
@@ -20,20 +20,21 @@ request 200 newsession?surveyid=del_decremential
 # Get the session ID that newsession should have returned
 extract_sessionid
 
-request 200 addanswer?sessionid=$SESSION&answer=question1:Answer+1:0:0:0:0:0:0:0:
+#! ------- answer 3 questions -------
+request 200 addanswer?sessionid=$SESSION&answer=question1:Answer+1:0:0:0:0:0:0:0::0
 match_string {"next_questions": [{"id": "question2", "name": "question2", "title": "Question 2", "description": "", "type": "TEXT", "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=question2:Answer+2:0:0:0:0:0:0:0:
+request 200 addanswer?sessionid=$SESSION&answer=question2:Answer+2:0:0:0:0:0:0:0::0
 match_string {"next_questions": [{"id": "question3", "name": "question3", "title": "Question 3", "description": "", "type": "TEXT", "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=question3:Answer+3:0:0:0:0:0:0:0:
+request 200 addanswer?sessionid=$SESSION&answer=question3:Answer+3:0:0:0:0:0:0:0::0
 match_string {"next_questions": []}
 
 verify_session
-del_decremential/a8df47cf88569fdd9d16b9b40ab41e5ddef4a21b
-question1:Answer 1:0:0:0:0:0:0:0:
-question2:Answer 2:0:0:0:0:0:0:0:
-question3:Answer 3:0:0:0:0:0:0:0:
+del_decremential/0b39e0c93f1b338433b8a8773d57f738dd405e17
+question1:Answer 1:0:0:0:0:0:0:0::0
+question2:Answer 2:0:0:0:0:0:0:0::0
+question3:Answer 3:0:0:0:0:0:0:0::0
 endofsession
 
 #! ------- delanswer question 3 -------
@@ -41,7 +42,7 @@ request 200 delanswer?sessionid=$SESSION&questionid=question3
 match_string {"next_questions": [{"id": "question3", "name": "question3", "title": "Question 3", "description": "", "type": "TEXT", "unit": ""}]}
 
 verify_session
-del_decremential/a8df47cf88569fdd9d16b9b40ab41e5ddef4a21b
+del_decremential/0b39e0c93f1b338433b8a8773d57f738dd405e17
 question1:Answer 1:0:0:0:0:0:0:0:
 question2:Answer 2:0:0:0:0:0:0:0:
 endofsession
@@ -51,7 +52,7 @@ request 200 delanswer?sessionid=$SESSION&questionid=question2
 match_string {"next_questions": [{"id": "question2", "name": "question2", "title": "Question 2", "description": "", "type": "TEXT", "unit": ""}]}
 
 verify_session
-del_decremential/a8df47cf88569fdd9d16b9b40ab41e5ddef4a21b
+del_decremential/0b39e0c93f1b338433b8a8773d57f738dd405e17
 question1:Answer 1:0:0:0:0:0:0:0:
 endofsession
 
@@ -60,5 +61,5 @@ request 200 delanswer?sessionid=$SESSION&questionid=question1
 match_string {"next_questions": [{"id": "question1", "name": "question1", "title": "Question 1", "description": "", "type": "TEXT", "unit": ""}]}
 
 verify_session
-del_decremential/a8df47cf88569fdd9d16b9b40ab41e5ddef4a21b
+del_decremential/0b39e0c93f1b338433b8a8773d57f738dd405e17
 endofsession


### PR DESCRIPTION
1. add env[SURVEY_PYTHON_DIR] to lighttpd test config workaround for currently hardcoded py syspath imports in tests
2. `skip!` flag to invalid or incomplete tests example: `skip! description My incomplete test`
3.  `stop_lighttpd()` kills multiple pids running on test port (curr only single)
4. add mkdir test_dir/logs to `main()`
5. disabling a number of invalid/incomplete python tests who need to be revised