### PR TITLE
backend delanswerandfollowing test and test_runner fixes

### DIFF
--- a/backend/src/errorlog.c
+++ b/backend/src/errorlog.c
@@ -40,7 +40,7 @@ int remember_error(const char *severity,const char *file,const int line, const c
     if (error_count>=MAX_ERRORS) {
       fprintf(stderr,"Too many errors encountered.  Error trace:\n");
       dump_errors(stderr);
-      exit(-1);
+      clear_errors();
     }
 
     va_list argp;

--- a/backend/src/fcgimain.c
+++ b/backend/src/fcgimain.c
@@ -805,7 +805,7 @@ static void fcgi_delanswerandfollowing(struct kreq *req)
     }
     else if (question&&question->val) {
       // No answer give, so delete all answers to the given question
-      if (session_delete_answers_by_question_uid(s,question->val,0)<0) {
+      if (session_delete_answers_by_question_uid(s,question->val,1)<0) {
 	quick_error(req,KHTTP_400,"session_delete_answers_by_question_uid() failed");
 	break;
       }      

--- a/backend/src/nextquestion.c
+++ b/backend/src/nextquestion.c
@@ -26,34 +26,51 @@ wchar_t *as_wchar(const char *s)
   else return as_wchar_out;
 }
 
-void log_python_error(void)
+int is_python_started=0;
+PyObject *nq_python_module=NULL;
+
+void log_python_error()
 {
   int retVal=0;
+  char *tb_function = "cmodule_traceback";
   do {
-    //    if (PyErr_Occurred()) {
     if (1) {
       PyObject *ptype=NULL,*pvalue=NULL,*ptraceback=NULL;
       PyErr_Fetch(&ptype,&pvalue,&ptraceback);
+      PyErr_NormalizeException(&ptype, &pvalue, &ptraceback);
       PyObject* objectsRepresentation = PyObject_Repr(ptype);
       const char* s = PyUnicode_AsUTF8(objectsRepresentation);
       LOG_WARNV("Python exception type: %s",s);
       objectsRepresentation = PyObject_Repr(pvalue);
       const char *s2 = PyUnicode_AsUTF8(objectsRepresentation);
       LOG_WARNV("Python error value: %s",s2);
-      objectsRepresentation = PyObject_Repr(ptraceback);
-      const char *s3 = PyUnicode_AsUTF8(objectsRepresentation);
-      LOG_WARNV("Python back-trace: %s",s3); 
+      
+      // Fetch a printable traceback string via an optional python callback. There seems to be no convenient way to serialise this via the bindings.
+      // Another way to do this might be to create a Python CustomError class with a traceback string injected into the message.
+      // However, this would only work if the CustomError is deliberately raised. This method might seem like an overhead but provides tracebacks for any exception type.
+      // todo: enable/disable this via a debug flag
+      if(!nq_python_module) break;
+      PyObject* callable = PyObject_GetAttrString(nq_python_module,tb_function);
+      
+      if(callable) {
+	PyObject* args = PyTuple_Pack(3,ptype,pvalue,ptraceback);
+	PyObject* result = PyObject_CallObject(callable, args);
+	Py_DECREF(args);
+	if (!result) {
+	  LOG_WARNV("Could not build Python error traceback with function (%s)",tb_function);
+	} else {
+	  LOG_WARNV("Python error traceback: %s",PyUnicode_AsUTF8(result));
+	}
+      } else {
+	LOG_WARNV("Unable to build traceback Python function (%s) missing!",tb_function);
+      }
     }
-    
   } while(0);
 
   (void)retVal;
   return;
 }
 
-
-int is_python_started=0;
-PyObject *nq_python_module=NULL;
 int setup_python(char *search_path)
 {
   int retVal=0;
@@ -367,7 +384,14 @@ int call_python_nextquestion(struct session *s,
     
     PyObject* result = PyObject_CallObject(myFunction, args);
     Py_DECREF(args);
-
+    
+    if(PyErr_Occurred()) {
+      is_error=1;
+      log_python_error();
+      LOG_ERRORV("Python function '%s' exited with an Error (PyErr_Occurred()). Check the backtrace and error messages above, in case they give you any clues.)",function_name);
+      PyErr_Clear();
+    }
+    
     if (!result) {
       is_error=1;
       log_python_error();
@@ -615,6 +639,13 @@ int get_analysis(struct session *s,const unsigned char **output)
     PyObject* result = PyObject_CallObject(myFunction, args);
     Py_DECREF(args);
 
+    if(PyErr_Occurred()) {
+      is_error=1;
+      log_python_error();
+      LOG_ERRORV("Python function '%s' exited with an Error (PyErr_Occurred()). Check the backtrace and error messages above, in case they give you any clues.)",function_name);
+      PyErr_Clear();
+    }
+    
     if (!result) {
       is_error=1;
       log_python_error();

--- a/backend/src/test_runner.c
+++ b/backend/src/test_runner.c
@@ -838,6 +838,10 @@ int run_test(char *dir, char *test_file)
 
         session_line[0]=0; fgets(session_line,8192,s);
         comparison_line[0]=0; fgets(comparison_line,8192,in);
+        
+        int verify_errors=0;
+        int verify_line=0;
+        
         while(1) {
           tdelta=gettime_us()-start_time; tdelta/=1000;
           if (comparison_line[0]&&strcmp(comparison_line,"endofsession")) {
@@ -851,6 +855,16 @@ int run_test(char *dir, char *test_file)
             while (len&&(session_line[len-1]=='\r'||session_line[len-1]=='\n')) session_line[--len]=0;
             fprintf(log,">>> %s\n",session_line);
           } else fprintf(log,">>>>>> END OF SESSION FILE\n");
+          
+          // compare session line, we are relying on the string terminations set above
+          if(verify_line>0) { // TODO for now(!) we ignore the header line with the hashed session id
+            if((session_line[0] && comparison_line[0]) && strcmp(comparison_line,"endofsession")) {
+                if(strcmp(session_line,comparison_line)) {
+                    // fprintf(log, "    - MISMATCH <<< %s >>> %s (line %d)\n",session_line,comparison_line, verify_line); // debug
+                    verify_errors++;
+                }
+            }
+          }
 
           if (session_line[0]&&(!strcmp("endofsession",comparison_line))) {
             // End of comparison list before end of session file
@@ -867,12 +881,21 @@ int run_test(char *dir, char *test_file)
           }
 
           if (!strcmp("endofsession",comparison_line)) break;
-
+          
+          verify_line++;
           session_line[0]=0; fgets(session_line,8192,s);
           comparison_line[0]=0; fgets(comparison_line,8192,in);
         }
 
         fclose(s);
+        
+        // fail if session contents mismatch
+        if(verify_errors) {
+            fprintf(log,"T+%4.3fms : FAIL : verifysession: %d lines in session file do not match!.\n",tdelta, verify_errors);
+            goto fail;
+        } else {
+            fprintf(log,"T+%4.3fms : verifysession: session file matches comparasion.\n",tdelta);
+        }
       }
       else if (line[0]==0) {
         // Ignore blank lines

--- a/backend/tests/QTYPE_CHECKBOX.test
+++ b/backend/tests/QTYPE_CHECKBOX.test
@@ -23,11 +23,11 @@ endofsession
 request 200 nextquestion?sessionid=$SESSION
 match_string {"next_questions": [{"id": "AreYouAwake", "name": "AreYouAwake", "title": "Are you awake?", "description": "Are you awake?", "type": "CHECKBOX", "choices": ["Unchecked", "Checked"], "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=AreYouAwake::28:0:0:0:0:0:0:days:0
+request 200 addanswer?sessionid=$SESSION&answer=AreYouAwake:Checked:0:0:0:0:0:0:0::0
 match_string {"next_questions": []}
 
 # Make sure answer ends up in file
 verify_session
 field_unit/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
-AreYouAwake::Checked:0:0:0:0:0:0::0
+AreYouAwake:Checked:0:0:0:0:0:0:0::0
 endofsession

--- a/backend/tests/character-encoding.test
+++ b/backend/tests/character-encoding.test
@@ -24,9 +24,9 @@ endofsession
 request 200 nextquestion?sessionid=$SESSION
 match_string {"next_questions": [{"id": "characterencoding", "name": "characterencoding", "title": "Select one from the ‘following’", "description": "Description for ‘following’", "type": "SINGLECHOICE", "choices": ["`31`", "`42ö`", "ümlaut"], "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=characterencoding:Ford:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=characterencoding:96ö:0:0:0:0:0:0:0::0
 # Make sure answer ends up in file
 verify_session
 field_unit/ee0a452e61f1a1a6f11084f9af7cbf2ac69cb728
-characterencoding:`42ö`:0:0:0:0:0:0:0::0
+characterencoding:96ö:0:0:0:0:0:0:0::0
 endofsession

--- a/backend/tests/delanswer-basic.test
+++ b/backend/tests/delanswer-basic.test
@@ -42,5 +42,5 @@ match_string {"next_questions": []}
 
 verify_session
 del_basic/0b39e0c93f1b338433b8a8773d57f738dd405e17
-question1:NEW+Answer:0:0:0:0:0:0:0::0
+question1:NEW Answer:0:0:0:0:0:0:0::0
 endofsession

--- a/backend/tests/delanswerandfollowing.test
+++ b/backend/tests/delanswerandfollowing.test
@@ -1,0 +1,50 @@
+description delanswerandfollowing
+
+#!---------------------
+#!running delanswer randomly
+#!---------------------
+
+# Create a dummy survey
+definesurvey delanswerandfollowing
+version 2
+Silly test survey updated
+without python
+question1:Question 1::TEXT:0::-1:-1:0:0::
+question2:Question 2::TEXT:0::-1:-1:0:0::
+question3:Question 3::TEXT:0::-1:-1:0:0::
+endofsurvey
+
+# Request creation of a  new session
+request 200 newsession?surveyid=delanswerandfollowing
+
+# Get the session ID that newsession should have returned
+extract_sessionid
+
+#! ------- answer 3 questions -------
+request 200 addanswer?sessionid=$SESSION&answer=question1:Answer+1:0:0:0:0:0:0:0::0
+match_string {"next_questions": [{"id": "question2", "name": "question2", "title": "Question 2", "description": "", "type": "TEXT", "unit": ""}]}
+
+request 200 addanswer?sessionid=$SESSION&answer=question2:Answer+2:0:0:0:0:0:0:0::0
+match_string {"next_questions": [{"id": "question3", "name": "question3", "title": "Question 3", "description": "", "type": "TEXT", "unit": ""}]}
+
+request 200 addanswer?sessionid=$SESSION&answer=question3:Answer+3:0:0:0:0:0:0:0::0
+match_string {"next_questions": []}
+
+verify_session
+delanswerandfollowing/0b39e0c93f1b338433b8a8773d57f738dd405e17
+question1:Answer 1:0:0:0:0:0:0:0::0
+question2:Answer 2:0:0:0:0:0:0:0::0
+question3:Answer 3:0:0:0:0:0:0:0::0
+endofsession
+
+#! ------- delanswer question 1 -------
+request 200 delanswerandfollowing?sessionid=$SESSION&questionid=question1
+match_string {"next_questions": [{"id": "question1", "name": "question1", "title": "Question 1", "description": "", "type": "TEXT", "default_value": "Answer 1", "unit": ""}]}
+
+verify_session
+delanswerandfollowing/0b39e0c93f1b338433b8a8773d57f738dd405e17
+question1:Answer 1:0:0:0:0:0:0:0::1
+question2:Answer 2:0:0:0:0:0:0:0::1
+question3:Answer 3:0:0:0:0:0:0:0::1
+endofsession
+

--- a/backend/tests/field_description.test
+++ b/backend/tests/field_description.test
@@ -37,5 +37,5 @@ match_string {"next_questions": []}
 verify_session
 field_description/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
 question1::5:0:0:0:0:0:0::0
-question1::-5:0:0:0:0:0:0::0
+question2::-5:0:0:0:0:0:0::0
 endofsession


### PR DESCRIPTION
- temporary fix for error overflow issue #198
- tests for delanswerandfollowing #186
- #217 add strcmp(session_line,comparasion_line) to test runner
- fix some existing tests (yes, most of them are mine:))
- fix #217 set `deleteFollowingP` arg to `1` in fcgi_delanswerandfollowing

- #147 improve `nextquestion` error detection, add support for `def cmodule_traceback(exc_type, exc_value, exc_tb)` for logging error tracebacks

There seems to be no convenient way to serialise this via the bindings, it always results in a null pointer or a stringified handler like `<traceback object at 0x7f1e184f2f48>`

example: 

```python
'''
 returns a printable traceback string for a given error
'''
def cmodule_traceback(exc_type, exc_value, exc_tb):
    import sys, traceback
    lines = []; 
    lines = traceback.format_exception(exc_type, exc_value, exc_tb)
    output = '\n'.join(lines)
    return output
```
