### PR TITLE
Backend

### DIFF
--- a/backend/include/serialisers.h
+++ b/backend/include/serialisers.h
@@ -5,7 +5,7 @@ int compare_answers(struct answer *a1, struct answer *a2, int mismatchIsError);
 int serialise_question(struct question *q,char *out,int max_len);
 int serialise_answer(struct answer *a,char *out,int max_len);
 int deserialise_question(char *in,struct question *q);
-int deserialise_answer(char *in,struct answer *a);
+int deserialise_answer(char *in, enum answer_visibility visibility, struct answer *a);
 int dump_question(FILE *f,char *msg,struct question *q);
 int dump_answerr(FILE *f,char *msg,struct answer *a);
 

--- a/backend/include/survey.h
+++ b/backend/include/survey.h
@@ -93,6 +93,11 @@ struct question {
 };
 
 struct answer {
+  
+  /* 
+   * Answer values (writable by REST API)
+   */
+  
   // ID of question being answered
   char *uid;
 
@@ -120,10 +125,23 @@ struct answer {
   int dst_delta;
   // #72 unit field
   char *unit;
+  
+  /* 
+   * Control fields (writable by backend only, readable by backend and nextquestion controllers
+   */
 
   // #186 flags
   int flags;
+  
+  // #162 answer storage timestamp
+  long long stored;
+  
 #define ANSWER_DELETED 1
+};
+
+enum answer_visibility {
+  ANSWER_FIELDS_PUBLIC,
+  ANSWER_FIELDS_PROTECTED,
 };
 
 #define MAX_QUESTIONS 8192

--- a/backend/src/fcgimain.c
+++ b/backend/src/fcgimain.c
@@ -121,9 +121,9 @@ int kvalid_answer(struct kpair *kp) {
       LOG_ERROR("Could not calloc() answer structure.");
     }
     
-    // XXX Remember deserialised answer and keep it in memory to save parsing twice?
+    // TODO XXX Remember deserialised answer and keep it in memory to save parsing twice? alternatively just basic validation by counting delimiters
     
-    if (deserialise_answer(kp->val,a)) {
+    if (deserialise_answer(kp->val, ANSWER_FIELDS_PUBLIC, a)) {
       free_answer(a);
       LOG_ERROR("deserialise_answer() failed");
     } else {
@@ -568,7 +568,7 @@ static void fcgi_addanswer(struct kreq *req)
       break;
     }
 
-    if (deserialise_answer(answer->val,a)) {
+    if (deserialise_answer(answer->val, ANSWER_FIELDS_PUBLIC, a)) {
       free_answer(a); a=NULL;
       quick_error(req,KHTTP_400,"Could not deserialise answer.");
       LOG_ERROR("deserialise_answer() failed.");
@@ -666,7 +666,7 @@ static void fcgi_updateanswer(struct kreq *req)
       break;
     }
     
-    if (deserialise_answer(answer->val,a)) {
+    if (deserialise_answer(answer->val, ANSWER_FIELDS_PUBLIC, a)) {
       free_answer(a); a=NULL;
       quick_error(req,KHTTP_400,"Could not deserialise answer.");
       LOG_ERROR("deserialise_answer() failed.");
@@ -797,7 +797,7 @@ static void fcgi_delanswer(struct kreq *req)
 	break;
       }
 
-      if (deserialise_answer(answer->val,a)) {
+      if (deserialise_answer(answer->val, ANSWER_FIELDS_PUBLIC, a)) {
 	if (a) free_answer(a);
 	a=NULL;
 	quick_error(req,KHTTP_400,"Could not deserialise answer.");
@@ -931,7 +931,7 @@ static void fcgi_delanswerandfollowing(struct kreq *req)
 	break;
       }
       
-      if (deserialise_answer(answer->val,a)) {
+      if (deserialise_answer(answer->val, ANSWER_FIELDS_PUBLIC, a)) {
 	if (a) free_answer(a);
 	a=NULL;
 	quick_error(req,KHTTP_400,"Could not deserialise answer.");

--- a/backend/src/main.c
+++ b/backend/src/main.c
@@ -40,7 +40,7 @@ int main(int argc,char **argv)
       if (!s) LOG_ERRORV("load_session('%s') failed",session_id);
       struct answer a;
       bzero(&a,sizeof(struct answer));
-      if (deserialise_answer(serialised_answer,&a)) LOG_ERRORV("deserialise_answer('%s') failed",serialised_answer);
+      if (deserialise_answer(serialised_answer, ANSWER_FIELDS_PUBLIC, &a)) LOG_ERRORV("deserialise_answer('%s') failed",serialised_answer);
       if (!s) LOG_ERRORV("load_session('%s') failed",session_id);
       if (session_add_answer(s,&a)) LOG_ERRORV("session_add_answer('%s','%s') failed",session_id,serialised_answer);
       if (save_session(s)) LOG_ERRORV("save_session('%s') failed",session_id);
@@ -54,7 +54,7 @@ int main(int argc,char **argv)
       if (!s) LOG_ERRORV("load_session('%s') failed",session_id);
       struct answer a;
       bzero(&a,sizeof(struct answer));
-      if (deserialise_answer(serialised_answer,&a)) LOG_ERRORV("deserialise_answer('%s') failed",serialised_answer);
+      if (deserialise_answer(serialised_answer, ANSWER_FIELDS_PUBLIC, &a)) LOG_ERRORV("deserialise_answer('%s') failed",serialised_answer);
       if (!s) LOG_ERRORV("load_session('%s') failed",session_id);
       if (session_delete_answers_by_question_uid(s,a.uid,0)<0) LOG_ERRORV("session_delete_answers_by_question_uid('%s','%s') failed",session_id,serialised_answer);
       if (session_add_answer(s,&a)) LOG_ERRORV("session_add_answer('%s','%s') failed",session_id,serialised_answer);
@@ -85,7 +85,7 @@ int main(int argc,char **argv)
       if (strstr(serialised_answer,":")) {
 	struct answer a;
 	bzero(&a,sizeof(struct answer));
-	if (deserialise_answer(serialised_answer,&a)) LOG_ERRORV("deserialise_answer('%s') failed",serialised_answer);
+	if (deserialise_answer(serialised_answer, ANSWER_FIELDS_PUBLIC, &a)) LOG_ERRORV("deserialise_answer('%s') failed",serialised_answer);
 	if (session_delete_answer(s,&a,0)) LOG_ERRORV("session_delete_answer('%s','%s') failed",session_id,serialised_answer);
       } else {
 	if (session_delete_answers_by_question_uid(s,serialised_answer,0)) LOG_ERRORV("session_delete_answers_by_question_uid('%s','%s') failed",session_id,serialised_answer);

--- a/backend/src/test_runner.c
+++ b/backend/src/test_runner.c
@@ -330,7 +330,7 @@ int compare_session_line(char *session_line, char *comparison_line) {
       int now = (int) time(NULL); 
       int then = atoi(left);
       
-      if (now < then || now - then > 8600) {
+      if (now <= 0 || now < then || now - then > 8600) {
         return -4;
       } 
       

--- a/backend/tests/POST-answerquestion.test
+++ b/backend/tests/POST-answerquestion.test
@@ -26,5 +26,5 @@ match_string {"next_questions": [{"id": "question2", "name": "question2", "title
 # Make sure answer ends up in file
 verify_session
 postrequests/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
-question1:Hello World:0:0:0:0:0:0:0:
+question1:Hello World:0:0:0:0:0:0:0::0:<UTIME>
 endofsession

--- a/backend/tests/QTYPE_CHECKBOX.test
+++ b/backend/tests/QTYPE_CHECKBOX.test
@@ -23,11 +23,11 @@ endofsession
 request 200 nextquestion?sessionid=$SESSION
 match_string {"next_questions": [{"id": "AreYouAwake", "name": "AreYouAwake", "title": "Are you awake?", "description": "Are you awake?", "type": "CHECKBOX", "choices": ["Unchecked", "Checked"], "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=AreYouAwake:Checked:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=AreYouAwake:Checked:0:0:0:0:0:0:0:
 match_string {"next_questions": []}
 
 # Make sure answer ends up in file
 verify_session
 field_unit/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
-AreYouAwake:Checked:0:0:0:0:0:0:0::0
+AreYouAwake:Checked:0:0:0:0:0:0:0::0:<UTIME>
 endofsession

--- a/backend/tests/QTYPE_DATETIME_SEQUENCE.test
+++ b/backend/tests/QTYPE_DATETIME_SEQUENCE.test
@@ -25,13 +25,13 @@ match_string {"next_questions": [{"id": "dates", "name": "dates", "title": "Your
 
 #! ------- answer question -------
 
-request 200 addanswer?sessionid=$SESSION&answer=dates:-26258313,171165687,345171687:0:0:0:0:0:0:0:seconds:0
+request 200 addanswer?sessionid=$SESSION&answer=dates:-26258313,171165687,345171687:0:0:0:0:0:0:0:seconds
 match_string {"next_questions": []}
 
 # Make sure answer ends up in file
 verify_session
 field_unit/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
-dates:-26258313,171165687,345171687:0:0:0:0:0:0:0:seconds:0
+dates:-26258313,171165687,345171687:0:0:0:0:0:0:0:seconds:0:<UTIME>
 endofsession
 
 #! ------- delete question -------
@@ -41,5 +41,5 @@ match_string {"next_questions": [{"id": "dates", "name": "dates", "title": "Your
 # Make sure answer ends up in file
 verify_session
 field_unit/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
-dates:-26258313,171165687,345171687:0:0:0:0:0:0:0:seconds:1
+dates:-26258313,171165687,345171687:0:0:0:0:0:0:0:seconds:1:<UTIME>
 endofsession

--- a/backend/tests/QTYPE_DAYTIME_SEQUENCE.test
+++ b/backend/tests/QTYPE_DAYTIME_SEQUENCE.test
@@ -25,13 +25,13 @@ match_string {"next_questions": [{"id": "meals", "name": "meals", "title": "Your
 
 #! ------- answer question -------
 
-request 200 addanswer?sessionid=$SESSION&answer=meals:27000,43200,66600,75600:0:0:0:0:0:0:0:seconds:0
+request 200 addanswer?sessionid=$SESSION&answer=meals:27000,43200,66600,75600:0:0:0:0:0:0:0:seconds
 match_string {"next_questions": []}
 
 # Make sure answer ends up in file
 verify_session
 field_unit/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
-meals:27000,43200,66600,75600:0:0:0:0:0:0:0:seconds:0
+meals:27000,43200,66600,75600:0:0:0:0:0:0:0:seconds:0:<UTIME>
 endofsession
 
 #! ------- delete question -------
@@ -42,5 +42,5 @@ match_string {"next_questions": [{"id": "meals", "name": "meals", "title": "Your
 # Make sure answer ends up in file
 verify_session
 field_unit/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
-meals:27000,43200,66600,75600:0:0:0:0:0:0:0:seconds:1
+meals:27000,43200,66600,75600:0:0:0:0:0:0:0:seconds:1:<UTIME>
 endofsession

--- a/backend/tests/QTYPE_DIALOG_DATA_CRAWLER.test
+++ b/backend/tests/QTYPE_DIALOG_DATA_CRAWLER.test
@@ -23,11 +23,11 @@ endofsession
 request 200 nextquestion?sessionid=$SESSION
 match_string {"next_questions": [{"id": "datacrawler", "name": "datacrawler", "title": "Do you consent to give us access?", "description": "You will be redirected!", "type": "DIALOG_DATA_CRAWLER", "choices": ["Denied", "Granted"], "unit": "toycollection-module"}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=datacrawler:Granted:0:0:0:0:0:0:0:toycollection-module:0
+request 200 addanswer?sessionid=$SESSION&answer=datacrawler:Granted:0:0:0:0:0:0:0:toycollection-module
 match_string {"next_questions": []}
 
 # Make sure answer ends up in file
 verify_session
 field_unit/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
-datacrawler:Granted:0:0:0:0:0:0:0:toycollection-module:0
+datacrawler:Granted:0:0:0:0:0:0:0:toycollection-module:0:<UTIME>
 endofsession

--- a/backend/tests/QTYPE_DURATION24.test
+++ b/backend/tests/QTYPE_DURATION24.test
@@ -23,11 +23,11 @@ endofsession
 request 200 nextquestion?sessionid=$SESSION
 match_string {"next_questions": [{"id": "duration24", "name": "duration24", "title": "How long do you brush your teeth?", "description": "", "type": "DURATION24", "unit": "seconds"}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=duration24::3600:0:0:0:0:0:0:seconds:0
+request 200 addanswer?sessionid=$SESSION&answer=duration24::3600:0:0:0:0:0:0:seconds
 match_string {"next_questions": []}
 
 # Make sure answer ends up in file
 verify_session
 field_unit/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
-duration24::3600:0:0:0:0:0:0:seconds:0
+duration24::3600:0:0:0:0:0:0:seconds:0:<UTIME>
 endofsession

--- a/backend/tests/QTYPE_FIXEDPOINT_SEQUENCE.test
+++ b/backend/tests/QTYPE_FIXEDPOINT_SEQUENCE.test
@@ -25,13 +25,13 @@ match_string {"next_questions": [{"id": "sequence", "name": "sequence", "title":
 
 #! ------- answer question -------
 
-request 200 addanswer?sessionid=$SESSION&answer=sequence:0,5.5,30.8:0:0:0:0:0:0:0:cm:0
+request 200 addanswer?sessionid=$SESSION&answer=sequence:0,5.5,30.8:0:0:0:0:0:0:0:cm
 match_string {"next_questions": []}
 
 # Make sure answer ends up in file
 verify_session
 field_unit/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
-sequence:0,5.5,30.8:0:0:0:0:0:0:0:cm:0
+sequence:0,5.5,30.8:0:0:0:0:0:0:0:cm:0:<UTIME>
 endofsession
 
 #! ------- delete question -------
@@ -42,5 +42,5 @@ match_string {"next_questions": [{"id": "sequence", "name": "sequence", "title":
 # Make sure answer ends up in file
 verify_session
 field_unit/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
-sequence:0,5.5,30.8:0:0:0:0:0:0:0:cm:1
+sequence:0,5.5,30.8:0:0:0:0:0:0:0:cm:1:<UTIME>
 endofsession

--- a/backend/tests/QTYPE_MULTICHOICE.test
+++ b/backend/tests/QTYPE_MULTICHOICE.test
@@ -23,11 +23,11 @@ endofsession
 request 200 nextquestion?sessionid=$SESSION
 match_string {"next_questions": [{"id": "multichoice", "name": "multichoice", "title": "Select any from the following", "description": "Select any from the following", "type": "MULTICHOICE", "choices": ["Zaphod", "Marvin", "Arthur", "Ford", "Trillan"], "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=multichoice:Marvin,Ford:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=multichoice:Marvin,Ford:0:0:0:0:0:0:0:
 match_string {"next_questions": []}
 
 # Make sure answer ends up in file
 verify_session
 field_unit/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
-multichoice:Marvin,Ford:0:0:0:0:0:0:0::0
+multichoice:Marvin,Ford:0:0:0:0:0:0:0::0:<UTIME>
 endofsession

--- a/backend/tests/QTYPE_MULTISELECT.test
+++ b/backend/tests/QTYPE_MULTISELECT.test
@@ -23,11 +23,11 @@ endofsession
 request 200 nextquestion?sessionid=$SESSION
 match_string {"next_questions": [{"id": "multiselect", "name": "multiselect", "title": "Select any from the following", "description": "Select any from the following", "type": "MULTISELECT", "choices": ["Zaphod", "Marvin", "Arthur", "Ford", "Trillan"], "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=multiselect:Marvin,Ford:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=multiselect:Marvin,Ford:0:0:0:0:0:0:0:
 match_string {"next_questions": []}
 
 # Make sure answer ends up in file
 verify_session
 field_unit/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
-multiselect:Marvin,Ford:0:0:0:0:0:0:0::0
+multiselect:Marvin,Ford:0:0:0:0:0:0:0::0:<UTIME>
 endofsession

--- a/backend/tests/QTYPE_SINGLECHOICE.test
+++ b/backend/tests/QTYPE_SINGLECHOICE.test
@@ -23,11 +23,11 @@ endofsession
 request 200 nextquestion?sessionid=$SESSION
 match_string {"next_questions": [{"id": "singlechoice", "name": "singlechoice", "title": "Select one from the following", "description": "Select one from the following", "type": "SINGLECHOICE", "choices": ["Zaphod", "Marvin", "Arthur", "Ford", "Trillan"], "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=singlechoice:Ford:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=singlechoice:Ford:0:0:0:0:0:0:0:
 match_string {"next_questions": []}
 
 # Make sure answer ends up in file
 verify_session
 field_unit/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
-singlechoice:Ford:0:0:0:0:0:0:0::0
+singlechoice:Ford:0:0:0:0:0:0:0::0:<UTIME>
 endofsession

--- a/backend/tests/QTYPE_SINGLESELECT.test
+++ b/backend/tests/QTYPE_SINGLESELECT.test
@@ -23,11 +23,11 @@ endofsession
 request 200 nextquestion?sessionid=$SESSION
 match_string {"next_questions": [{"id": "singleselect", "name": "singleselect", "title": "Select one from the following", "description": "Select one from the following", "type": "SINGLESELECT", "choices": ["Zaphod", "Marvin", "Arthur", "Ford", "Trillan"], "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=singleselect:Ford:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=singleselect:Ford:0:0:0:0:0:0:0:
 match_string {"next_questions": []}
 
 # Make sure answer ends up in file
 verify_session
 field_unit/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
-singleselect:Ford:0:0:0:0:0:0:0::0
+singleselect:Ford:0:0:0:0:0:0:0::0:<UTIME>
 endofsession

--- a/backend/tests/answer_visibility.test
+++ b/backend/tests/answer_visibility.test
@@ -1,0 +1,40 @@
+description Answer field visibility, protected fields
+
+# Create a dummy survey
+definesurvey foo
+version 2
+Silly test survey updated
+without python
+question1:Question 1::TEXT:0::-1:-1:0:0::
+question2:Question 2::TEXT:0::-1:-1:0:0::
+endofsurvey
+
+# Request creation of a new session
+request 200 newsession?surveyid=foo
+
+# Get the session ID that newsession should have returned
+extract_sessionid
+
+# Check that we have an empty session file created
+verify_session
+foo/a8df47cf88569fdd9d16b9b40ab41e5ddef4a21b
+endofsession
+
+#! ------- default addanswer: request does not include values for protected fields -------
+request 200 addanswer?sessionid=$SESSION&answer=question1:answer1:0:0:0:0:0:0:0:
+
+# Make sure answer ends up in file
+verify_session
+foo/a8df47cf88569fdd9d16b9b40ab41e5ddef4a21b
+question1:answer1:0:0:0:0:0:0:0::0:<UTIME>
+endofsession
+
+#! ------- "overambitious" addanswer: ignore the request's included values for protected fields: 'flag' and 'stored' -------
+request 200 addanswer?sessionid=$SESSION&answer=question2:answer2:0:0:0:0:0:0:0::-1:-1
+
+# Make sure answer 'flag' and 'stored' are unchanged (not accepting the silly values in request)
+verify_session
+foo/a8df47cf88569fdd9d16b9b40ab41e5ddef4a21b
+question1:answer1:0:0:0:0:0:0:0::0:<UTIME>
+question2:answer2:0:0:0:0:0:0:0::0:<UTIME>
+endofsession

--- a/backend/tests/answernonexistantquestion.test
+++ b/backend/tests/answernonexistantquestion.test
@@ -2,8 +2,9 @@ description Answer a question in a survey
 
 # Create a dummy survey
 definesurvey foo
-version 1
+version 2
 Silly test survey updated
+without python
 multichoice:Select one of the following:Select one of the following:MULTICHOICE:0::-1:-1:-1:3:Yes,No,Maybe:
 question1:What is the answer to question 1?:What is the answer to question 1?:TEXT:0:I don't know:-1:-1:0:0::
 question2:How boring was question 1?:How boring was question 1?:TEXT:0:I don't know:-1:-1:0:0::
@@ -20,7 +21,7 @@ verify_session
 foo/d7ab1e207abe98dad5985a1ec18c96da8bed01a4
 endofsession
 
-request 400 addanswer?sessionid=$SESSION&answer=nosuchquestion:Hello+World:0:0:0:0:0:0:0::0
+request 400 addanswer?sessionid=$SESSION&answer=nosuchquestion:Hello+World:0:0:0:0:0:0:0:
 
 # Check that we are offered the next question to answer
 

--- a/backend/tests/answerquestion.test
+++ b/backend/tests/answerquestion.test
@@ -21,12 +21,12 @@ verify_session
 foo/a8df47cf88569fdd9d16b9b40ab41e5ddef4a21b
 endofsession
 
-request 200 addanswer?sessionid=$SESSION&answer=question1:Hello+World:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question1:Hello+World:0:0:0:0:0:0:0:
 
 # Check that we are offered the next question to answer
 
 # Make sure answer ends up in file
 verify_session
 foo/a8df47cf88569fdd9d16b9b40ab41e5ddef4a21b
-question1:Hello World:0:0:0:0:0:0:0::0
+question1:Hello World:0:0:0:0:0:0:0::0:<UTIME>
 endofsession

--- a/backend/tests/character-encoding.test
+++ b/backend/tests/character-encoding.test
@@ -24,9 +24,9 @@ endofsession
 request 200 nextquestion?sessionid=$SESSION
 match_string {"next_questions": [{"id": "characterencoding", "name": "characterencoding", "title": "Select one from the ‘following’", "description": "Description for ‘following’", "type": "SINGLECHOICE", "choices": ["`31`", "`42ö`", "ümlaut"], "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=characterencoding:96ö:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=characterencoding:96ö:0:0:0:0:0:0:0:
 # Make sure answer ends up in file
 verify_session
 field_unit/ee0a452e61f1a1a6f11084f9af7cbf2ac69cb728
-characterencoding:96ö:0:0:0:0:0:0:0::0
+characterencoding:96ö:0:0:0:0:0:0:0::0:<UTIME>
 endofsession

--- a/backend/tests/delanswer-basic.test
+++ b/backend/tests/delanswer-basic.test
@@ -19,12 +19,12 @@ request 200 newsession?surveyid=del_basic
 extract_sessionid
 
 #! ------- answer question -------
-request 200 addanswer?sessionid=$SESSION&answer=question1:Answer+1:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question1:Answer+1:0:0:0:0:0:0:0:
 match_string {"next_questions": []}
 
 verify_session
 del_basic/0b39e0c93f1b338433b8a8773d57f738dd405e17
-question1:Answer 1:0:0:0:0:0:0:0::0
+question1:Answer 1:0:0:0:0:0:0:0::0:<UTIME>
 endofsession
 
 #! ------- delanswer question -------
@@ -33,14 +33,14 @@ match_string {"next_questions": [{"id": "question1", "name": "question1", "title
 
 verify_session
 del_basic/0b39e0c93f1b338433b8a8773d57f738dd405e17
-question1:Answer 1:0:0:0:0:0:0:0::1
+question1:Answer 1:0:0:0:0:0:0:0::1:<UTIME>
 endofsession
 
 #! ------- answer question again -------
-request 200 addanswer?sessionid=$SESSION&answer=question1:NEW+Answer:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question1:NEW+Answer:0:0:0:0:0:0:0:
 match_string {"next_questions": []}
 
 verify_session
 del_basic/0b39e0c93f1b338433b8a8773d57f738dd405e17
-question1:NEW Answer:0:0:0:0:0:0:0::0
+question1:NEW Answer:0:0:0:0:0:0:0::0:<UTIME>
 endofsession

--- a/backend/tests/delanswer-decremential.test
+++ b/backend/tests/delanswer-decremential.test
@@ -21,20 +21,20 @@ request 200 newsession?surveyid=del_decremential
 extract_sessionid
 
 #! ------- answer 3 questions -------
-request 200 addanswer?sessionid=$SESSION&answer=question1:Answer+1:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question1:Answer+1:0:0:0:0:0:0:0:
 match_string {"next_questions": [{"id": "question2", "name": "question2", "title": "Question 2", "description": "", "type": "TEXT", "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=question2:Answer+2:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question2:Answer+2:0:0:0:0:0:0:0:
 match_string {"next_questions": [{"id": "question3", "name": "question3", "title": "Question 3", "description": "", "type": "TEXT", "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=question3:Answer+3:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question3:Answer+3:0:0:0:0:0:0:0:
 match_string {"next_questions": []}
 
 verify_session
 del_decremential/0b39e0c93f1b338433b8a8773d57f738dd405e17
-question1:Answer 1:0:0:0:0:0:0:0::0
-question2:Answer 2:0:0:0:0:0:0:0::0
-question3:Answer 3:0:0:0:0:0:0:0::0
+question1:Answer 1:0:0:0:0:0:0:0::0:<UTIME>
+question2:Answer 2:0:0:0:0:0:0:0::0:<UTIME>
+question3:Answer 3:0:0:0:0:0:0:0::0:<UTIME>
 endofsession
 
 #! ------- delanswer question 3 -------
@@ -43,9 +43,9 @@ match_string {"next_questions": [{"id": "question3", "name": "question3", "title
 
 verify_session
 del_decremential/0b39e0c93f1b338433b8a8773d57f738dd405e17
-question1:Answer 1:0:0:0:0:0:0:0::0
-question2:Answer 2:0:0:0:0:0:0:0::0
-question3:Answer 3:0:0:0:0:0:0:0::1
+question1:Answer 1:0:0:0:0:0:0:0::0:<UTIME>
+question2:Answer 2:0:0:0:0:0:0:0::0:<UTIME>
+question3:Answer 3:0:0:0:0:0:0:0::1:<UTIME>
 endofsession
 
 
@@ -55,9 +55,9 @@ match_string {"next_questions": [{"id": "question2", "name": "question2", "title
 
 verify_session
 del_decremential/0b39e0c93f1b338433b8a8773d57f738dd405e17
-question1:Answer 1:0:0:0:0:0:0:0::0
-question2:Answer 2:0:0:0:0:0:0:0::1
-question3:Answer 3:0:0:0:0:0:0:0::1
+question1:Answer 1:0:0:0:0:0:0:0::0:<UTIME>
+question2:Answer 2:0:0:0:0:0:0:0::1:<UTIME>
+question3:Answer 3:0:0:0:0:0:0:0::1:<UTIME>
 endofsession
 
 #! ------- delanswer question 1 -------
@@ -66,7 +66,7 @@ match_string {"next_questions": [{"id": "question1", "name": "question1", "title
 
 verify_session
 del_decremential/0b39e0c93f1b338433b8a8773d57f738dd405e17
-question1:Answer 1:0:0:0:0:0:0:0::1
-question2:Answer 2:0:0:0:0:0:0:0::1
-question3:Answer 3:0:0:0:0:0:0:0::1
+question1:Answer 1:0:0:0:0:0:0:0::1:<UTIME>
+question2:Answer 2:0:0:0:0:0:0:0::1:<UTIME>
+question3:Answer 3:0:0:0:0:0:0:0::1:<UTIME>
 endofsession

--- a/backend/tests/delanswer-non-decremential.test
+++ b/backend/tests/delanswer-non-decremential.test
@@ -21,20 +21,20 @@ request 200 newsession?surveyid=del_non_decremential
 extract_sessionid
 
 #! ------- answer 3 questions -------
-request 200 addanswer?sessionid=$SESSION&answer=question1:Answer+1:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question1:Answer+1:0:0:0:0:0:0:0:
 match_string {"next_questions": [{"id": "question2", "name": "question2", "title": "Question 2", "description": "", "type": "TEXT", "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=question2:Answer+2:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question2:Answer+2:0:0:0:0:0:0:0:
 match_string {"next_questions": [{"id": "question3", "name": "question3", "title": "Question 3", "description": "", "type": "TEXT", "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=question3:Answer+3:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question3:Answer+3:0:0:0:0:0:0:0:
 match_string {"next_questions": []}
 
 verify_session
 del_non_decremential/0b39e0c93f1b338433b8a8773d57f738dd405e17
-question1:Answer 1:0:0:0:0:0:0:0::0
-question2:Answer 2:0:0:0:0:0:0:0::0
-question3:Answer 3:0:0:0:0:0:0:0::0
+question1:Answer 1:0:0:0:0:0:0:0::0:<UTIME>
+question2:Answer 2:0:0:0:0:0:0:0::0:<UTIME>
+question3:Answer 3:0:0:0:0:0:0:0::0:<UTIME>
 endofsession
 
 #! ------- delanswer question 2 -------
@@ -43,9 +43,9 @@ match_string {"next_questions": [{"id": "question2", "name": "question2", "title
 
 verify_session
 del_non_decremential/0b39e0c93f1b338433b8a8773d57f738dd405e17
-question1:Answer 1:0:0:0:0:0:0:0::0
-question2:Answer 2:0:0:0:0:0:0:0::1
-question3:Answer 3:0:0:0:0:0:0:0::0
+question1:Answer 1:0:0:0:0:0:0:0::0:<UTIME>
+question2:Answer 2:0:0:0:0:0:0:0::1:<UTIME>
+question3:Answer 3:0:0:0:0:0:0:0::0:<UTIME>
 endofsession
 
 #! ------- delanswer question 1 -------
@@ -54,7 +54,7 @@ match_string {"next_questions": [{"id": "question1", "name": "question1", "title
 
 verify_session
 del_non_decremential/0b39e0c93f1b338433b8a8773d57f738dd405e17
-question1:Answer 1:0:0:0:0:0:0:0::1
-question2:Answer 2:0:0:0:0:0:0:0::1
-question3:Answer 3:0:0:0:0:0:0:0::0
+question1:Answer 1:0:0:0:0:0:0:0::1:<UTIME>
+question2:Answer 2:0:0:0:0:0:0:0::1:<UTIME>
+question3:Answer 3:0:0:0:0:0:0:0::0:<UTIME>
 endofsession

--- a/backend/tests/delanswer-twice.test
+++ b/backend/tests/delanswer-twice.test
@@ -19,12 +19,12 @@ request 200 newsession?surveyid=del_answer_twice
 extract_sessionid
 
 #! ------- answer question -------
-request 200 addanswer?sessionid=$SESSION&answer=question1:Answer+1:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question1:Answer+1:0:0:0:0:0:0:0:
 match_string {"next_questions": []}
 
 verify_session
 del_answer_twice/0b39e0c93f1b338433b8a8773d57f738dd405e17
-question1:Answer 1:0:0:0:0:0:0:0::0
+question1:Answer 1:0:0:0:0:0:0:0::0:<UTIME>
 endofsession
 
 #! ------- delanswer question first time-------
@@ -33,7 +33,7 @@ match_string {"next_questions": [{"id": "question1", "name": "question1", "title
 
 verify_session
 del_answer_twice/0b39e0c93f1b338433b8a8773d57f738dd405e17
-question1:Answer 1:0:0:0:0:0:0:0::1
+question1:Answer 1:0:0:0:0:0:0:0::1:<UTIME>
 endofsession
 
 #! ------- delanswer question second time-------
@@ -42,6 +42,6 @@ match_string {"next_questions": [{"id": "question1", "name": "question1", "title
 
 verify_session
 del_answer_twice/0b39e0c93f1b338433b8a8773d57f738dd405e17
-question1:Answer 1:0:0:0:0:0:0:0::1
+question1:Answer 1:0:0:0:0:0:0:0::1:<UTIME>
 endofsession
 

--- a/backend/tests/delanswerandfollowing-python.test
+++ b/backend/tests/delanswerandfollowing-python.test
@@ -71,20 +71,20 @@ request 200 newsession?surveyid=delanswerandfollowingpython
 extract_sessionid
 
 #! ------- answer 3 questions -------
-request 200 addanswer?sessionid=$SESSION&answer=question1:Answer+1:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question1:Answer+1:0:0:0:0:0:0:0:
 match_string {"next_questions": [{"id": "question2", "name": "question2", "title": "Question 2", "description": "", "type": "TEXT", "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=question2:Answer+2:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question2:Answer+2:0:0:0:0:0:0:0:
 match_string {"next_questions": [{"id": "question3", "name": "question3", "title": "Question 3", "description": "", "type": "TEXT", "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=question3:Answer+3:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question3:Answer+3:0:0:0:0:0:0:0:
 match_string {"next_questions": []}
 
 verify_session
 delanswerandfollowingpython/0b39e0c93f1b338433b8a8773d57f738dd405e17
-question1:Answer 1:0:0:0:0:0:0:0::0
-question2:Answer 2:0:0:0:0:0:0:0::0
-question3:Answer 3:0:0:0:0:0:0:0::0
+question1:Answer 1:0:0:0:0:0:0:0::0:<UTIME>
+question2:Answer 2:0:0:0:0:0:0:0::0:<UTIME>
+question3:Answer 3:0:0:0:0:0:0:0::0:<UTIME>
 endofsession
 
 #! ------- delanswer question 1 -------
@@ -93,7 +93,7 @@ match_string {"next_questions": [{"id": "question1", "name": "question1", "title
 
 verify_session
 delanswerandfollowingpython/0b39e0c93f1b338433b8a8773d57f738dd405e17
-question1:Answer 1:0:0:0:0:0:0:0::1
-question2:Answer 2:0:0:0:0:0:0:0::1
-question3:Answer 3:0:0:0:0:0:0:0::1
+question1:Answer 1:0:0:0:0:0:0:0::1:<UTIME>
+question2:Answer 2:0:0:0:0:0:0:0::1:<UTIME>
+question3:Answer 3:0:0:0:0:0:0:0::1:<UTIME>
 endofsession

--- a/backend/tests/delanswerandfollowing.test
+++ b/backend/tests/delanswerandfollowing.test
@@ -21,20 +21,20 @@ request 200 newsession?surveyid=delanswerandfollowing
 extract_sessionid
 
 #! ------- answer 3 questions -------
-request 200 addanswer?sessionid=$SESSION&answer=question1:Answer+1:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question1:Answer+1:0:0:0:0:0:0:0:
 match_string {"next_questions": [{"id": "question2", "name": "question2", "title": "Question 2", "description": "", "type": "TEXT", "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=question2:Answer+2:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question2:Answer+2:0:0:0:0:0:0:0:
 match_string {"next_questions": [{"id": "question3", "name": "question3", "title": "Question 3", "description": "", "type": "TEXT", "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=question3:Answer+3:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question3:Answer+3:0:0:0:0:0:0:0:
 match_string {"next_questions": []}
 
 verify_session
 delanswerandfollowing/0b39e0c93f1b338433b8a8773d57f738dd405e17
-question1:Answer 1:0:0:0:0:0:0:0::0
-question2:Answer 2:0:0:0:0:0:0:0::0
-question3:Answer 3:0:0:0:0:0:0:0::0
+question1:Answer 1:0:0:0:0:0:0:0::0:<UTIME>
+question2:Answer 2:0:0:0:0:0:0:0::0:<UTIME>
+question3:Answer 3:0:0:0:0:0:0:0::0:<UTIME>
 endofsession
 
 #! ------- delanswer question 1 -------
@@ -43,8 +43,8 @@ match_string {"next_questions": [{"id": "question1", "name": "question1", "title
 
 verify_session
 delanswerandfollowing/0b39e0c93f1b338433b8a8773d57f738dd405e17
-question1:Answer 1:0:0:0:0:0:0:0::1
-question2:Answer 2:0:0:0:0:0:0:0::1
-question3:Answer 3:0:0:0:0:0:0:0::1
+question1:Answer 1:0:0:0:0:0:0:0::1:<UTIME>
+question2:Answer 2:0:0:0:0:0:0:0::1:<UTIME>
+question3:Answer 3:0:0:0:0:0:0:0::1:<UTIME>
 endofsession
 

--- a/backend/tests/field_description.test
+++ b/backend/tests/field_description.test
@@ -26,16 +26,16 @@ request 200 nextquestion?sessionid=$SESSION
 match_string {"next_questions": [{"id": "question1", "name": "question1", "title": "This is the first title", "description": "This is the first description", "type": "INT", "unit": ""}]}
 
 # answer question
-request 200 addanswer?sessionid=$SESSION&answer=question1::5:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question1::5:0:0:0:0:0:0:
 match_string {"next_questions": [{"id": "question2", "name": "question2", "title": "This is the second title", "description": "This is the <strong>second HTML description<\/strong>", "type": "INT", "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=question2::-5:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question2::-5:0:0:0:0:0:0:
 match_string {"next_questions": []}
 
 
 # Make sure answer ends up in file
 verify_session
 field_description/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
-question1::5:0:0:0:0:0:0::0
-question2::-5:0:0:0:0:0:0::0
+question1::5:0:0:0:0:0:0::0:<UTIME>
+question2::-5:0:0:0:0:0:0::0:<UTIME>
 endofsession

--- a/backend/tests/field_unit.test
+++ b/backend/tests/field_unit.test
@@ -23,11 +23,11 @@ endofsession
 request 200 nextquestion?sessionid=$SESSION
 match_string {"next_questions": [{"id": "question1", "name": "question1", "title": "How many days are in February?", "description": "How many days are in February?", "type": "INT", "unit": "days"}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=question1::28:0:0:0:0:0:0:days:0
+request 200 addanswer?sessionid=$SESSION&answer=question1::28:0:0:0:0:0:0:days
 match_string {"next_questions": []}
 
 # Make sure answer ends up in file
 verify_session
 field_unit/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
-question1::28:0:0:0:0:0:0:days:0
+question1::28:0:0:0:0:0:0:days:0:<UTIME>
 endofsession

--- a/backend/tests/invalid_next_question.test
+++ b/backend/tests/invalid_next_question.test
@@ -16,8 +16,8 @@ endofsurvey
 python
 """
 def nextquestion(questions, answers):
-        print (questions, answers)
-        return ["question2"]
+    print (questions, answers)
+    return ["question2"]
 """
 endofpython
 

--- a/backend/tests/sequencedanswering.test
+++ b/backend/tests/sequencedanswering.test
@@ -24,26 +24,26 @@ endofsession
 request 200 nextquestion?sessionid=$SESSION
 match_string {"next_questions": [{"id": "question1", "name": "question1", "title": "Select one of the following", "description": "", "type": "MULTICHOICE", "choices": ["Yes", "No", "Maybe"], "unit": ""}]}
 
-request 200 addanswer?sessionid=$SESSION&answer=question1:Hello+World:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question1:Hello+World:0:0:0:0:0:0:0:
 match_string {"next_questions": [{"id": "question2", "name": "question2", "title": "What is the answer to question 1?", "description": "", "type": "TEXT", "unit": ""}]}
 
 # Make sure answer ends up in file
 verify_session
 foo/d4f5a62de47e9a5ea38f93c304d6c4cdee1e396c
-question1:Hello World:0:0:0:0:0:0:0::0
+question1:Hello World:0:0:0:0:0:0:0::0:<UTIME>
 endofsession
 
-request 200 addanswer?sessionid=$SESSION&answer=question2:Another+answer:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question2:Another+answer:0:0:0:0:0:0:0:
 match_string {"next_questions": [{"id": "question3", "name": "question3", "title": "How boring was question 2?", "description": "", "type": "TEXT", "unit": ""}]}
 
 # Make sure answer ends up in file
 verify_session
 foo/d4f5a62de47e9a5ea38f93c304d6c4cdee1e396c
-question1:Hello World:0:0:0:0:0:0:0::0
-question2:Another answer:0:0:0:0:0:0:0::0
+question1:Hello World:0:0:0:0:0:0:0::0:<UTIME>
+question2:Another answer:0:0:0:0:0:0:0::0:<UTIME>
 endofsession
 
-request 200 addanswer?sessionid=$SESSION&answer=question3:Last+answer:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question3:Last+answer:0:0:0:0:0:0:0:
 
 # Check that we are offered the next question to answer
 match_string {"next_questions": []}
@@ -51,7 +51,7 @@ match_string {"next_questions": []}
 # Make sure answer ends up in file
 verify_session
 foo/d4f5a62de47e9a5ea38f93c304d6c4cdee1e396c
-question1:Hello World:0:0:0:0:0:0:0::0
-question2:Another answer:0:0:0:0:0:0:0::0
-question3:Last answer:0:0:0:0:0:0:0::0
+question1:Hello World:0:0:0:0:0:0:0::0:<UTIME>
+question2:Another answer:0:0:0:0:0:0:0::0:<UTIME>
+question3:Last answer:0:0:0:0:0:0:0::0:<UTIME>
 endofsession

--- a/backend/tests/version1_nextquestion_modes.test
+++ b/backend/tests/version1_nextquestion_modes.test
@@ -27,14 +27,14 @@ without_python/a8df47cf88569fdd9d16b9b40ab41e5ddef4a21b
 endofsession
 
 # should not invoke python and return 500 misconfiguration error
-request 500 addanswer?sessionid=$SESSION&answer=question1:Hello+World:0:0:0:0:0:0:0::0
+request 500 addanswer?sessionid=$SESSION&answer=question1:Hello+World:0:0:0:0:0:0:0:
 
 # Check that we are offered the next question to answer
 
 # Make sure answer ends up in file
 verify_session
 without_python/a8df47cf88569fdd9d16b9b40ab41e5ddef4a21b
-question1:Hello World:0:0:0:0:0:0:0::0
+question1:Hello World:0:0:0:0:0:0:0::0:<UTIME>
 endofsession
 
 #!---------------------
@@ -70,7 +70,7 @@ verify_session
 with_python/a8df47cf88569fdd9d16b9b40ab41e5ddef4a21b
 endofsession
 
-request 200 addanswer?sessionid=$SESSION&answer=question1:Hello+World:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question1:Hello+World:0:0:0:0:0:0:0:
 match_string {"next_questions": [{"id": "question3", "name": "question3", "title": "Question 3", "description": "", "type": "TEXT", "unit": ""}]}
 
 # Check that we are offered the next question to answer
@@ -78,5 +78,5 @@ match_string {"next_questions": [{"id": "question3", "name": "question3", "title
 # Make sure answer ends up in file
 verify_session
 with_python/a8df47cf88569fdd9d16b9b40ab41e5ddef4a21b
-question1:Hello World:0:0:0:0:0:0:0::0
+question1:Hello World:0:0:0:0:0:0:0::0:<UTIME>
 endofsession

--- a/backend/tests/version2_nextquestion_modes.test
+++ b/backend/tests/version2_nextquestion_modes.test
@@ -35,7 +35,7 @@ without_python/a8df47cf88569fdd9d16b9b40ab41e5ddef4a21b
 endofsession
 
 # should not invoke python and return next question
-request 200 addanswer?sessionid=$SESSION&answer=question1:Hello+World:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question1:Hello+World:0:0:0:0:0:0:0:
 match_string {"next_questions": [{"id": "question2", "name": "question2", "title": "Question 2", "description": "", "type": "TEXT", "unit": ""}]}
 
 # Check that we are offered the next question to answer
@@ -43,7 +43,7 @@ match_string {"next_questions": [{"id": "question2", "name": "question2", "title
 # Make sure answer ends up in file
 verify_session
 without_python/a8df47cf88569fdd9d16b9b40ab41e5ddef4a21b
-question1:Hello World:0:0:0:0:0:0:0::0
+question1:Hello World:0:0:0:0:0:0:0::0:<UTIME>
 endofsession
 
 #!---------------------
@@ -80,7 +80,7 @@ verify_session
 with_python/a8df47cf88569fdd9d16b9b40ab41e5ddef4a21b
 endofsession
 
-request 200 addanswer?sessionid=$SESSION&answer=question1:Hello+World:0:0:0:0:0:0:0::0
+request 200 addanswer?sessionid=$SESSION&answer=question1:Hello+World:0:0:0:0:0:0:0:
 match_string {"next_questions": [{"id": "question3", "name": "question3", "title": "Question 3", "description": "", "type": "TEXT", "unit": ""}]}
 
 # Check that we are offered the next question to answer
@@ -88,5 +88,5 @@ match_string {"next_questions": [{"id": "question3", "name": "question3", "title
 # Make sure answer ends up in file
 verify_session
 with_python/a8df47cf88569fdd9d16b9b40ab41e5ddef4a21b
-question1:Hello World:0:0:0:0:0:0:0::0
+question1:Hello World:0:0:0:0:0:0:0::0:<UTIME>
 endofsession

--- a/docs/data-serialization.md
+++ b/docs/data-serialization.md
@@ -60,19 +60,20 @@ Format of an answer row:
 
 Location: `sessions/<session-prefix>/sessionID`
 
-| field                 | data type | json   | notes       |
-| ---                   | ---       | ---    | ---         |
-| **uid**               | char[]    | string | question id |
-| **text**              | char[]    | string |             |
-| **value**             | long long | number |             |
-| **lat**               | long long | number |             |
-| **lon**               | long long | number |             |
-| **time_begin**        | long long | number |             |
-| **time_end**          | long long | number |             |
-| **time_zone_delta**   | int       | number |             |
-| **dst_delta**         | int       | number |             |
-| **unit**              | char[]    | string | unit for numeric types, see below   |
-| **flag**              | int       | string | bit flags, currently only, see below |
+| field                 | API access |               | data type | json   | notes       |
+| ---                   | ---        | ---           | ---       | ---    | ---         |
+| **uid**               | read/write | answer value  | char[]    | string | question id |
+| **text**              | read/write | answer value  | char[]    | string |             |
+| **value**             | read/write | answer value  | long long | number |             |
+| **lat**               | read/write | answer value  | long long | number |             |
+| **lon**               | read/write | answer value  | long long | number |             |
+| **time_begin**        | read/write | answer value  | long long | number |             |
+| **time_end**          | read/write | answer value  | long long | number |             |
+| **time_zone_delta**   | read/write | answer value  | int       | number |             |
+| **dst_delta**         | read/write | answer value  | int       | number |             |
+| **unit**              | read/write | answer value  | char[]    | string | unit for numeric types, see below   |
+| **flag**              | -          | control field | int       | -      | bit control flag, see below |
+| **stored**            | -          | control field | long long | -      | UNIX timestamp, time of answer storage, see below |
 
 **unit**
 
@@ -82,3 +83,7 @@ Location: `sessions/<session-prefix>/sessionID`
 **flag**
 
 - Currently only supported flags are `answered` (0) or `deleted` (1)
+
+**stored**
+
+- timestamp is set on adding, deleting or updating an answer: *addanswer*, *updateanswer*, *delanswer*, *delanswerandfollowing*


### PR DESCRIPTION
* **test_runner.c**: `int compare_session_line(char *session_line, char *comparison_line) `
compares session file line content delimiter by delimiter(`:`). adds `<UTIME>` keyword for usage in comarasion_line. Indicates that the opposite session part MUST be a Unix timestamp past now and not older than 1 hour.

simple test script for this func(): https://gist.github.com/RoboSparrow/dca42e54e51f5ee1e34fe36a13b3d876