### PR TITLE
backend: implement http POST /answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,15 @@ Note that the following section reflects the *current state* of development and 
 
 ### Paths and queries
 
-| Path                         | Action                                                                              | Method | Format           | Params                  | Return |
-| ---                          | ---                                                                                 | ---    | ---              | ---                     |  ---       |
-| **Session**                  |                                                                                     |        |                  |                         |         |
-| `newsession`                 | create a new survey session                                                         | GET    | application/text | `?surveyid`             | session id |
-| `newsession`                 | (Authorized MW only) managed session, create a new survey session with a given uid  | POST   | application/text | `?surveyid&sessionid`   | session id |
-| `delsession`                 | delete current session                                                              | GET    | application/text | `?sessionid`            | -       |
-| **Survey**                   |                                                                                     |        |                  |                         |         |
-| `nextquestion`               | get next questions                                                                  | GET    | application/json | `?sessionid`            | `{ status, message, next_questions[] }`<br> [next_questions response](docs/next-questions-response.md) |
+| Path                         | Action                                                                              | Method | Format           | Params                                | Return |
+| ---                          | ---                                                                                 | ---    | ---              | ---                                   |  ---       |
+| **Session**                  |                                                                                     |        |                  |                                       |         |
+| `newsession`                 | create a new survey session                                                         | GET    | application/text | `?surveyid`                           | session id |
+| `newsession`                 | (Authorized MW only) managed session, create a new survey session with a given uid  | POST   | application/text | `?surveyid&sessionid`                 | session id |
+| `delsession`                 | delete current session                                                              | GET    | application/text | `?sessionid`                          | -       |
+| **Survey**                   |                                                                                     |        |                  |                                       |         |
+| `nextquestion`               | get next questions                                                                  | GET    | application/json | `?sessionid`                          | `{ status, message, next_questions[] }`<br> [next_questions response](docs/next-questions-response.md) |
+| `answers`                    | provide a single (param `?answer`) or multiple answers `Content-Type: text/csv`and an anonymous body with lines of serialised answers, <br> based on previous questions | POST   | application/json | `?sessionid`<br />`?sessionid&answer` | `{ status, message, next_questions[] }` <br> [next_questions response](docs/next-questions-response.md) |
 | `addanswer`                  | provide a single answer and get next questions                                      | GET(!) | application/json | `?sessionid&answer`     | `{ status, message, next_questions[] }`<br> [next_questions response](docs/next-questions-response.md) |
 | `updateanswer`               | alias for addanswer                                                                 | GET(!) | application/json | `?sessionid&answer`     | `{ status, message, next_questions[] }`<br> [next_questions response](docs/next-questions-response.md) |
 | `delanswer`                  | remove all answers up to a specified question id and get next questions             | GET    | application/json | `?sessionid&questionid` | `{ status, message, next_questions[] }`<br> [*updated* next_questions response](docs/next-questions-response.md) |

--- a/backend/include/fcgi.h
+++ b/backend/include/fcgi.h
@@ -8,13 +8,13 @@
 #define X_HEADER_MW_GROUP "X-SurveyProxy-Auth-Group"
 
 // fcgi_main.c
-
 enum key { KEY_SURVEYID, KEY_SESSIONID, KEY_QUESTIONID, KEY_ANSWER, KEY__MAX };
 
 enum page {
   PAGE_INDEX, // #389 add root page
   PAGE_NEWSESSION,
   PAGE_ADDANSWER,
+  PAGE_ANSWERS, // #260, #461
   PAGE_UPDATEANSWER,
   PAGE_NEXTQUESTION,
   PAGE_DELANSWER,
@@ -31,6 +31,7 @@ enum page {
 struct session_meta *fcgi_request_parse_meta(struct kreq *req);
 enum khttp fcgi_request_validate_meta_kreq(struct kreq *req, struct session_meta *meta);
 enum khttp fcgi_request_validate_meta_session(struct kreq *req, struct session *ses);
+enum khttp fcgi_request_validate_method(struct kreq *req, enum kmethod allowed[], size_t length); // #260, #461
 
 char *fcgi_request_get_field_value(enum key field, struct kreq *req);
 struct answer *fcgi_request_load_answer(struct kreq *req);

--- a/backend/include/serialisers.h
+++ b/backend/include/serialisers.h
@@ -22,6 +22,7 @@ int serialise_question_type(int qt, char *out, int out_max_len); // #358
 int escape_string(char *in, char *out, int max_len);
 
 char *serialise_list_append_alloc(char *src, char *in, const char separator); // #482
+char **deserialise_list_alloc(char *in, const char separator, size_t *len); // #482
 
 int dump_question(FILE *f, struct question *q);
 int dump_answer(FILE *f, struct answer *a);

--- a/backend/include/survey.h
+++ b/backend/include/survey.h
@@ -275,6 +275,7 @@ int get_analysis(struct session *s, const char **output);
 int create_session_id(char *session_id_out, int max_len);
 struct session *create_session(char *survey_id, char *session_id, struct session_meta *meta);
 struct session *load_session(char *session_id);
+int session_load_survey(struct session *ses);
 int delete_session(char *session_id);
 int save_session(struct session *s);
 int session_add_answer(struct session *s, struct answer *a);

--- a/backend/src/main.c
+++ b/backend/src/main.c
@@ -119,6 +119,8 @@ int do_newsession(char *survey_id) {
   int retVal = 0;
 
   struct session *ses = NULL;
+  struct nextquestions *nq = NULL;
+  enum actions action = ACTION_SESSION_NEW;
 
   do {
     LOG_INFO("Entering newsession handler.");
@@ -140,6 +142,16 @@ int do_newsession(char *survey_id) {
     if (!ses) {
       fprintf(stderr, "failed to create session.\n");
       LOG_ERROR("Create session failed.");
+    }
+
+    // # 461 store nextquestions after creating session
+    nq = get_next_questions(ses, action, 0);
+    if (!nq) {
+      LOG_ERROR("get_next_questions() failed");
+    }
+
+    if (save_session(ses)) {
+      LOG_ERROR("save_session() failed");
     }
 
     printf("%s\n", session_id);

--- a/backend/src/serialisers.c
+++ b/backend/src/serialisers.c
@@ -500,6 +500,45 @@ char *serialise_list_append_alloc(char *src, char *in, const char separator) {
   return src;
 }
 
+
+/**
+ * deserialises a string into a char** array by a given separator.
+ */
+char **deserialise_list_alloc(char *in, const char separator, size_t *len) {
+  int retVal = 0;
+  char **list = NULL;
+
+  do {
+    *(len) = 0; // set length to zero before handling input
+
+    if(!in) {
+      break;
+    }
+
+    int count = serialiser_count_columns(',', in);
+
+    list = malloc(count * sizeof(char*));
+    if (!list) {
+      LOG_ERROR("error allocating memory for char** list ptr");
+    }
+    char *sav;
+    char *line = parse_line(in, separator, &sav);
+
+    while(line != NULL) {
+      list[*(len)] = line; // allocated already
+      // next
+      *(len)= *(len) + 1;
+      line = parse_line(NULL, separator, &sav);
+    }
+  } while (0);
+
+  if (retVal) {
+      return NULL;
+  }
+  return list;
+}
+
+
 /*
   Top-level function for serialising a question that has been passed in
   in a struct question.  It uses the various macros defined above to

--- a/backend/src/sessions.c
+++ b/backend/src/sessions.c
@@ -773,10 +773,10 @@ int dump_session(FILE *fp, struct session *ses) {
 }
 
 /**
-  * Load and deserialise the set of questions for the form corresponding to
-  * this session.
-  *
-  * #484 renamed and exposed to survey.h (load_survey_questions())
+ * Load and deserialise the set of questions for the form corresponding to
+ * this session.
+ *
+ * #484 renamed and exposed to survey.h (load_survey_questions())
  */
 int session_load_survey(struct session *ses) {
   int retVal = 0;

--- a/backend/src/test_units.c
+++ b/backend/src/test_units.c
@@ -484,7 +484,6 @@ int main(int argc, char **argv) {
       ASSERT(text == NULL, "NULL src and NULL fragment", "");
     }
 
-
     {
       char *text = strdup("test");
       text = serialise_list_append_alloc(text, "", ',');
@@ -505,6 +504,45 @@ int main(int argc, char **argv) {
       free(text);
     }
 
+    SECTION("deserialise char* array: deserialise_list_alloc()");
+
+    {
+      char *line = "uid1,uid2,uid3";
+      size_t len;
+      char **list = deserialise_list_alloc(line, ',', &len);
+
+      ASSERT(len == 3, "list length 3 == %ld", len);
+      ASSERT_STR_EQ(list[0], "uid1", "list item 1");
+      ASSERT_STR_EQ(list[1], "uid2", "list item 2");
+      ASSERT_STR_EQ(list[2], "uid3", "list item 3");
+
+      for (size_t i = 0; i < len; i++) {
+          free(list[i]);
+      }
+      free(list);
+    }
+
+    {
+      char *line = "uid1";
+      size_t len;
+      char **list = deserialise_list_alloc(line, ',', &len);
+
+      ASSERT(len == 1, "list length 1 == %ld", len);
+      ASSERT_STR_EQ(list[0], "uid1", "list item 1");
+
+      free(list[0]);
+      free(list);
+    }
+
+    {
+      char *line = NULL;
+      size_t len;
+      char **list = deserialise_list_alloc(line, ',', &len);
+printf(" * computed len=%ld\n", len);
+      ASSERT(len == 0, "list length 0 == %ld", len);
+      ASSERT(list == NULL, "list is NULL", "");
+
+    }
     /* tests for #392 */
     SECTION("escape_string() tests, issue #392");
 

--- a/backend/tests/POST-answers-multiple-python.test
+++ b/backend/tests/POST-answers-multiple-python.test
@@ -1,0 +1,193 @@
+@description POST requests /answers - multiple answers
+
+#!-------
+#!-- this test will run with python in order to return groups of nextquestions...
+#!-- ...because generic mode currently  only returns single question
+#!-------
+
+# Create a dummy survey
+definesurvey foo
+version 2
+Silly test survey updated
+with python
+single1:Question1::TEXT:0::-1:-1:0:0::
+grouped2:Grouped2::TEXT:0::-1:-1:0:0::
+grouped3:Grouped3::TEXT:0::-1:-1:0:0::
+single4:Question4::TEXT:0::-1:-1:0:0::
+endofsurvey
+
+# Create python module
+python
+def nextquestion(questions, answers, **kwargs):
+    current = answers[-1]['uid'] if answers else None
+    progress = [len(answers), len(questions)]
+
+    logging.info(list(map(lambda a: a['uid'], answers)))
+
+    if not current:
+        return {
+            'status': 0,
+            'message': '',
+            'progress': progress,
+            'next_questions': ['single1'],
+        }
+
+    if current == 'single1':
+        return {
+            'status': 0,
+            'message': '',
+            'progress': progress,
+            'next_questions': ['grouped2', 'grouped3'],
+        }
+
+    if current == 'grouped3':
+        return {
+            'status': 0,
+            'message': '',
+            'progress': progress,
+            'next_questions': ['single4'],
+        }
+
+    return {
+        'status': 0,
+        'message': '',
+        'progress': progress,
+        'next_questions': [],
+    }
+endofpython
+
+# Request creation of a  new session
+request 200 /newsession?surveyid=foo
+extract_sessionid
+
+verify_session
+foo/current
+@user:META::0:0:0:0:0:0:0::0:<UTIME>
+@group:META::0:0:0:0:0:0:0::0:<UTIME>
+@authority:META:<AUTHORITY_NONE>:<IDENDITY_HTTP_PUBLIC>:0:0:0:0:0:0::0:<UTIME>
+@state:META:single1:<SESSION_NEW>:0:0:<UTIME>:0:0:0::0:<UTIME>
+endofsession
+
+#! ------------
+#! -- PASS query initial nextquestions (session: open, nextquestions)
+#! ------------
+
+request 200 /nextquestion?sessionid=$SESSION
+match_string {"status": 0, "message": "", "progress": [0, 4], "next_questions": [{"id": "single1", "name": "single1", "title": "Question1", "description": "", "type": "TEXT", "default_value": "", "min_value": -1, "max_value": -1, "choices": [], "unit": ""}]}
+
+verify_session
+foo/current
+@user:META::0:0:0:0:0:0:0::0:<UTIME>
+@group:META::0:0:0:0:0:0:0::0:<UTIME>
+@authority:META:<AUTHORITY_NONE>:<IDENDITY_HTTP_PUBLIC>:0:0:0:0:0:0::0:<UTIME>
+@state:META:single1:<SESSION_NEW>:0:0:<UTIME>:0:0:0::0:<UTIME>
+endofsession
+
+#! ------------
+#! -- PASS add single answer (complete batch)
+#! ------------
+
+# prepare multiline data
+open_file(<TEST_DIR>/request.data)
+single1:Answer1:0:0:0:0:0:0:0
+close_file()
+
+request 200 /answers?sessionid=$SESSION curlargs(-X POST -H "Content-Type: text/csv" --data-binary @<TEST_DIR>/request.data)
+match_string {"status": 0, "message": "", "progress": [1, 4], "next_questions": [{"id": "grouped2", "name": "grouped2", "title": "Grouped2", "description": "", "type": "TEXT", "default_value": "", "min_value": -1, "max_value": -1, "choices": [], "unit": ""}, {"id": "grouped3", "name": "grouped3", "title": "Grouped3", "description": "", "type": "TEXT", "default_value": "", "min_value": -1, "max_value": -1, "choices": [], "unit": ""}]}
+
+verify_session
+foo/current
+@user:META::0:0:0:0:0:0:0::0:<UTIME>
+@group:META::0:0:0:0:0:0:0::0:<UTIME>
+@authority:META:<AUTHORITY_NONE>:<IDENDITY_HTTP_PUBLIC>:0:0:0:0:0:0::0:<UTIME>
+@state:META:grouped2,grouped3:<SESSION_OPEN>:0:0:<UTIME>:0:0:0::0:<UTIME>
+single1:TEXT:Answer1:0:0:0:0:0:0:0::0:<UTIME>
+endofsession
+
+#! ------------
+#! -- FAIL add single answer (incomplete batch)
+#! ------------
+
+# prepare multiline data
+open_file(<TEST_DIR>/request.data)
+grouped2:Answer2:0:0:0:0:0:0:0
+close_file()
+
+request 400 /answers?sessionid=$SESSION curlargs(-X POST -H "Content-Type: text/csv" --data-binary @<TEST_DIR>/request.data)
+
+#! ------------
+#! -- PASS add two answers (complete batch)
+#! ------------
+
+# prepare multiline data
+open_file(<TEST_DIR>/request.data)
+grouped2:Answer2:0:0:0:0:0:0:0
+grouped3:Answer3:0:0:0:0:0:0:0
+close_file()
+
+request 200 /answers?sessionid=$SESSION curlargs(-X POST -H "Content-Type: text/csv" --data-binary @<TEST_DIR>/request.data)
+match_string {"status": 0, "message": "", "progress": [3, 4], "next_questions": [{"id": "single4", "name": "single4", "title": "Question4", "description": "", "type": "TEXT", "default_value": "", "min_value": -1, "max_value": -1, "choices": [], "unit": ""}]}
+
+verify_session
+foo/current
+@user:META::0:0:0:0:0:0:0::0:<UTIME>
+@group:META::0:0:0:0:0:0:0::0:<UTIME>
+@authority:META:<AUTHORITY_NONE>:<IDENDITY_HTTP_PUBLIC>:0:0:0:0:0:0::0:<UTIME>
+@state:META:single4:<SESSION_OPEN>:0:0:<UTIME>:0:0:0::0:<UTIME>
+single1:TEXT:Answer1:0:0:0:0:0:0:0::0:<UTIME>
+grouped2:TEXT:Answer2:0:0:0:0:0:0:0::0:<UTIME>
+grouped3:TEXT:Answer3:0:0:0:0:0:0:0::0:<UTIME>
+endofsession
+
+#! ------------
+#! -- FAIL overwrite single answer (open session)
+#! ------------
+
+open_file(<TEST_DIR>/request.data)
+single1:Overwrite1:0:0:0:0:0:0:0
+close_file()
+
+request 400 /answers?sessionid=$SESSION curlargs(-X POST -H "Content-Type: text/csv" --data-binary @<TEST_DIR>/request.data)
+
+#! ------------
+#! -- FAIL overwrite multiple answers (open session)
+#! ------------
+
+open_file(<TEST_DIR>/request.data)
+grouped2:Overwrite2:0:0:0:0:0:0:0
+grouped3:Overwrite3:0:0:0:0:0:0:0
+close_file()
+
+request 400 /answers?sessionid=$SESSION curlargs(-X POST -H "Content-Type: text/csv" --data-binary @<TEST_DIR>/request.data)
+
+#! ------------
+#! -- PASS finish session
+#! ------------
+
+open_file(<TEST_DIR>/request.data)
+single4:Answer4:0:0:0:0:0:0:0
+close_file()
+
+request 200 /answers?sessionid=$SESSION curlargs(-X POST -H "Content-Type: text/csv" --data-binary @<TEST_DIR>/request.data)
+
+verify_session
+foo/current
+@user:META::0:0:0:0:0:0:0::0:<UTIME>
+@group:META::0:0:0:0:0:0:0::0:<UTIME>
+@authority:META:<AUTHORITY_NONE>:<IDENDITY_HTTP_PUBLIC>:0:0:0:0:0:0::0:<UTIME>
+@state:META::<SESSION_FINISHED>:0:0:<UTIME>:0:0:0::0:<UTIME>
+single1:TEXT:Answer1:0:0:0:0:0:0:0::0:<UTIME>
+grouped2:TEXT:Answer2:0:0:0:0:0:0:0::0:<UTIME>
+grouped3:TEXT:Answer3:0:0:0:0:0:0:0::0:<UTIME>
+single4:TEXT:Answer4:0:0:0:0:0:0:0::0:<UTIME>
+endofsession
+
+#! ------------
+#! -- FAIL overwrite finished session (open session)
+#! ------------
+
+open_file(<TEST_DIR>/request.data)
+single4:Overwrite4:0:0:0:0:0:0:0
+close_file()
+
+request 400 /answers?sessionid=$SESSION curlargs(-X POST -H "Content-Type: text/csv" --data-binary @<TEST_DIR>/request.data)

--- a/backend/tests/POST-answers.test
+++ b/backend/tests/POST-answers.test
@@ -1,0 +1,43 @@
+@description POST requests /answers - content types csv and urlencoded
+
+# Create a dummy survey
+definesurvey foo
+version 2
+Silly test survey updated
+without python
+question1:Question1::TEXT:0::-1:-1:0:0::
+question2:Question2::TEXT:0::-1:-1:0:0::
+endofsurvey
+
+# Request creation of a  new session
+request 200 /newsession?surveyid=foo
+extract_sessionid
+
+# Check that we have an empty session file created
+verify_session(skip_headers)
+foo/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
+endofsession
+
+request 200 /nextquestion?sessionid=$SESSION
+match_string {"status": 0, "message": "", "progress": [0, 2], "next_questions": [{"id": "question1", "name": "question1", "title": "Question1", "description": "", "type": "TEXT", "default_value": "", "min_value": -1, "max_value": -1, "choices": [], "unit": ""}]}
+
+#! -- PASS add single answer Content-Type: text/csv
+
+request 200 /answers?sessionid=$SESSION curlargs(-H "Content-Type: text/csv") POST "question1:Answer1:0:0:0:0:0:0:0"
+match_string {"status": 0, "message": "", "progress": [1, 2], "next_questions": [{"id": "question2", "name": "question2", "title": "Question2", "description": "", "type": "TEXT", "default_value": "", "min_value": -1, "max_value": -1, "choices": [], "unit": ""}]}
+
+#! -- FAIL overwrite single answer (open session)
+
+request 400 /answers?sessionid=$SESSION curlargs(-H "Content-Type: text/csv") POST "question1:Answer1:0:0:0:0:0:0:0"
+
+#! -- PASS add single answer Content-Type: application/x-www-form-urlencoded
+
+request 200 /answers?sessionid=$SESSION curlargs(-H "Content-Type: application/x-www-form-urlencoded") POST "answer=question2:Answer2:0:0:0:0:0:0:0"
+match_string {"status": 0, "message": "", "progress": [2, 2], "next_questions": []}
+
+# Make sure answer ends up in file
+verify_session(skip_headers)
+foo/current
+question1:TEXT:Answer1:0:0:0:0:0:0:0::0:<UTIME>
+question2:TEXT:Answer2:0:0:0:0:0:0:0::0:<UTIME>
+endofsession

--- a/backend/tests/session-lifetime.test
+++ b/backend/tests/session-lifetime.test
@@ -24,7 +24,7 @@ sessionlifetime/0a7caf5b02adad7583c7bfae30f6f119cb3581cc
 @user:META::0:0:0:0:0:0:0::0:<UTIME>
 @group:META::0:0:0:0:0:0:0::0:<UTIME>
 @authority:META:<AUTHORITY_NONE>:<IDENDITY_HTTP_PUBLIC>:0:0:0:0:0:0::0:<UTIME>
-@state:META::<SESSION_NEW>:0:0:<UTIME>:0:0:0::0:<UTIME>
+@state:META:question1:<SESSION_NEW>:0:0:<UTIME>:0:0:0::0:<UTIME>
 endofsession
 
 # copy_session_to SESSION_NEW

--- a/docs/development-notes.md
+++ b/docs/development-notes.md
@@ -1,6 +1,6 @@
-# Backed development notes
+# Development notes
 
-## Adding a new question type
+## 1. Adding a new question type
 
 ### Backend
 
@@ -19,4 +19,18 @@
 2. parser: Answer.js: `Answer.getValue()`
 3. add component
 4. register component: Question.jsx  `getComponentByType()`
+
+## 2. Adding answers workflow
+
+* (fcgi) validate req->method
+* load session
+* validate session->meta against request (user)
+* validate session against request action (state checks)
+* deserialise request answer data
+* validate answer against session->next_questions
+* add answers to session
+* get next questions and store in session
+* save session
+* return next questions
+
 


### PR DESCRIPTION
#461 

multiple answers are send with content type `text/csv` and an anonymous body, each line containing a serialised answer

```bash
curl -i -H "Content-Type: text/csv" -X POST -d "question1:Answer1:0:0:0:0:0:0:0\n"question2:Answer2:0:0:0:0:0:0:0" http://localhost:8099/surveyapi/answers?sessionid=77e905ee-0000-0000-465e-4e5ab51bdba4
```

single answers can also be send using the `?answer` param (see /addanswer)

```bash
curl -i -H "Content-Type: application/x-www-form-urlencoded" -X POST -d "answer=question2:Answer2:0:0:0:0:0:0:0" http://localhost:8099/surveyapi/answers?sessionid=77e905ee-0000-0000-465e-4e5ab51bdba4
```

#260 

**/answers** will replace `/addanswer` and `/updateanswer` endpoints